### PR TITLE
Fix reveal-current-file commands in Journal view

### DIFF
--- a/src/day.ts
+++ b/src/day.ts
@@ -11,6 +11,12 @@ import type { FindRange } from "./findText";
 export interface DayHost {
 	app: App;
 	plugin: JournalViewPlugin;
+	/** Updates the file/navigation state exposed by the journal pane. */
+	onDayFocusChanged(): void;
+	/** Opens a link without allowing it to replace the journal pane. */
+	openDayLink(linktext: string, sourcePath: string, newTab: boolean): Promise<void>;
+	/** Opens a note without allowing it to replace the journal pane. */
+	openDayFile(file: TFile, newTab: boolean): Promise<void>;
 	/** Called when a day's underlying file appears, disappears or is renamed. */
 	onDayFileChanged(day: DaySection, previousPath: string | null): void;
 	/** True for a day that stays in the journal even with empty days hidden. */
@@ -157,7 +163,7 @@ export class DaySection {
 			const href = link.getAttribute("data-href") ?? link.getAttribute("href");
 			if (!href) return;
 			if (link.classList.contains("internal-link")) {
-				void this.host.app.workspace.openLinkText(href, this.path, event.ctrlKey || event.metaKey);
+				void this.host.openDayLink(href, this.path, event.ctrlKey || event.metaKey);
 			} else if (/^https?:/.test(href)) {
 				window.open(href);
 			}
@@ -601,6 +607,7 @@ export class DaySection {
 					},
 					onFocus: () => {
 						this.focused = true;
+						this.host.onDayFocusChanged();
 						// Measurement should normally have released the guard before
 						// the reader arrives; focus is the defensive fallback.
 						this.releaseHeight();
@@ -672,6 +679,7 @@ export class DaySection {
 	/** Blurring an editor is not leaving the day, but it is a good time to save. */
 	private onEditorBlur(): void {
 		this.focused = false;
+		this.host.onDayFocusChanged();
 		this.el.removeClass("journal-day-focused");
 		// Leaving a day the reader only looked at costs them nothing.
 		if (this.withdrawTemplate()) return;
@@ -807,7 +815,7 @@ export class DaySection {
 				return;
 			}
 		}
-		await this.host.app.workspace.getLeaf(newTab ? "tab" : false).openFile(file);
+		await this.host.openDayFile(file, newTab);
 	}
 
 	destroy(): void {

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,4 +1,4 @@
-import { ItemView, Scope, TAbstractFile, TFile, WorkspaceLeaf } from "obsidian";
+import { FileView, Scope, TAbstractFile, TFile, WorkspaceLeaf } from "obsidian";
 import type JournalViewPlugin from "./main";
 import { AnchorHost, ScrollAnchor } from "./anchor";
 import { DatePickerModal } from "./datePicker";
@@ -50,7 +50,7 @@ type TimelineEnd = "start" | "end";
  * in the wrong place. Whatever height still drifts in afterwards is cancelled
  * out by `ScrollAnchor`.
  */
-export class JournalView extends ItemView implements DayHost, AnchorHost, EditorWindowHost, JournalFindHost {
+export class JournalView extends FileView implements DayHost, AnchorHost, EditorWindowHost, JournalFindHost {
 	scrollEl!: HTMLElement;
 	daysEl!: HTMLElement;
 	sections: DaySection[] = [];
@@ -105,6 +105,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		readonly plugin: JournalViewPlugin,
 	) {
 		super(leaf);
+		// The journal can open before today's note exists, but exposing the note
+		// through FileView lets Obsidian's file-aware commands act on it.
+		this.allowNoFile = true;
 		// Obsidian's workspace scope handles Escape before the find bar's DOM
 		// listener can. Claim it only while focus is in journal-wide find, leaving
 		// embedded-editor Escape handling (including Vim mode) untouched.
@@ -114,9 +117,10 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			return false;
 		});
 		this.initialDate = plugin.consumeInitialDate(leaf);
-		// Opening a note (from a day header, or a link inside a day) must not
-		// replace the journal itself.
-		this.navigation = false;
+		// This makes the origin note available to Obsidian's file-aware commands.
+		// A focused embedded editor publishes its own file instead, and temporarily
+		// opts the journal out so opening a link cannot replace the timeline.
+		this.navigation = true;
 	}
 
 	getViewType(): string {
@@ -276,6 +280,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			this.centerOn(this.sectionAt(origin), "instant");
 		} // else: the pane is hidden; the first real resize centres it.
 		this.updateHeaderLabel();
+		this.file = this.sectionAt(this.origin)?.file ?? null;
 		this.find?.sectionsChanged();
 
 		if (
@@ -660,6 +665,29 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.find?.show();
 	}
 
+	onDayFocusChanged(): void {
+		this.navigation = !this.sections.some((section) => section.hasFocus);
+	}
+
+	async openDayLink(linktext: string, sourcePath: string, newTab: boolean): Promise<void> {
+		await this.withNavigationSuppressed(() => this.app.workspace.openLinkText(linktext, sourcePath, newTab));
+	}
+
+	async openDayFile(file: TFile, newTab: boolean): Promise<void> {
+		await this.withNavigationSuppressed(() =>
+			this.app.workspace.getLeaf(newTab ? "tab" : false).openFile(file),
+		);
+	}
+
+	private async withNavigationSuppressed(action: () => Promise<void>): Promise<void> {
+		this.navigation = false;
+		try {
+			await action();
+		} finally {
+			this.onDayFocusChanged();
+		}
+	}
+
 	setFindMode(open: boolean): void {
 		this.toolbar?.setVisible(!open);
 	}
@@ -989,6 +1017,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		if (previousPath) this.byPath.delete(previousPath);
 		this.byPath.set(day.path, day);
 		if (day.file) this.byPath.set(day.file.path, day);
+		if (day.offset === this.origin) this.file = day.file;
 		this.syncMonthSeparators();
 	}
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/RUverse/journal-view/issues/1

- expose the journal as an Obsidian `FileView` backed by its origin daily note
- keep empty-note journals valid with `allowNoFile`
- preserve cursor-aware active files from embedded editors
- prevent links and day-header actions from replacing the journal while file navigation is enabled
- keep the exposed file in sync when the origin note is created or removed

## Verification

- `npm run typecheck`
- `npm run build`
- prepared the throwaway test vault and inspected Obsidian 1.12.7 active-file behavior; confirmed that file-aware commands require a navigation-enabled `FileView` and that the journal state exposes `Journal/2026-08-06.md` as its backing file

Runtime interaction testing was stopped when the active Obsidian window returned to the real vault, to avoid operating on user content.