### PR TITLE
Fix journal find without editor focus

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -113,6 +113,13 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			if (!this.find?.handleEscape(event)) return;
 			return false;
 		});
+		// The active leaf keeps this scope even when focus is not inside a day.
+		// A DOM listener alone misses Mod+F when the journal pane itself is
+		// selected but no embedded editor owns the active element.
+		this.scope.register(["Mod"], "f", () => {
+			this.showFind();
+			return false;
+		});
 		this.initialDate = plugin.consumeInitialDate(leaf);
 		// Opening a note (from a day header, or a link inside a day) must not
 		// replace the journal itself.


### PR DESCRIPTION
## Summary

- register Mod+F on the active Journal view scope
- open journal-wide find even when no embedded day editor owns focus
- retain the existing editor and DOM shortcut paths

## Verification

- `npm run typecheck`
- `npm run build`
- `npm run lint`

Live Obsidian verification was not run because Obsidian was not running in the test environment.