### PR TITLE
Add year grouping to the journal timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ vault handles daily notes.
 | --- | --- | --- |
 | Date format / Folder / Template | Inherited | Overrides your vault's daily-note settings for Journal View |
 | Day order | Oldest to newest | Reverses the complete timeline when set to newest to oldest |
+| Daily header format | `dddd, D MMMM` | Controls how each daily header displays its date |
+| Group days by year | On | Marks year boundaries between consecutive visible daily entries |
 | Group days by month | Off | Groups daily entries beneath compact month and year headings |
-| Show year separators | On | Marks year boundaries between consecutive visible daily entries |
-| Daily header format | `dddd, D MMMM` | Controls how each date appears when month grouping is off |
 | Focus today on open | On | Opens the journal at today's note and places the cursor there |
 | Only show days that have a note | On | Skips empty days while always keeping today visible; turn it off to show every day |
 | Rich editor | On | Uses Obsidian's Markdown editor; turn it off to use the plain-text fallback |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ vault handles daily notes.
 | Date format / Folder / Template | Inherited | Overrides your vault's daily-note settings for Journal View |
 | Day order | Oldest to newest | Reverses the complete timeline when set to newest to oldest |
 | Group days by month | Off | Groups daily entries beneath compact month and year headings |
+| Show year separators | On | Marks year boundaries between consecutive visible daily entries |
 | Daily header format | `dddd, D MMMM` | Controls how each date appears when month grouping is off |
 | Focus today on open | On | Opens the journal at today's note and places the cursor there |
 | Only show days that have a note | On | Skips empty days while always keeping today visible; turn it off to show every day |

--- a/src/anchor.ts
+++ b/src/anchor.ts
@@ -63,7 +63,9 @@ export class ScrollAnchor {
 			return;
 		}
 		const section = this.sectionNear(scrollEl.scrollTop);
-		this.pinned = section ? { el: section.el, section, top: section.el.offsetTop } : null;
+		// Date headings can move between days as notes appear or disappear. Pin
+		// the card below them so those changes count as layout drift too.
+		this.pinned = section ? { el: section.el, section, top: section.cardTop } : null;
 	}
 
 	/** The day the anchor should pin for a viewport whose top sits at `position`. */
@@ -99,7 +101,7 @@ export class ScrollAnchor {
 			return;
 		}
 
-		const top = this.pinned.el.offsetTop;
+		const top = this.pinned.section.cardTop;
 		const delta = top - this.pinned.top;
 		if (delta === 0) return;
 		const absorbed = this.absorbWithSpacer(delta);

--- a/src/day.ts
+++ b/src/day.ts
@@ -3,7 +3,6 @@ import type JournalViewPlugin from "./main";
 import { JournalEditor, createJournalEditor } from "./editor";
 import type { Moment } from "./moment";
 import { SaveQueue } from "./saveQueue";
-import { MONTH_SEPARATOR_DAY_FORMAT } from "./settings";
 import { findLiteralRanges } from "./findText";
 import type { FindRange } from "./findText";
 
@@ -287,10 +286,7 @@ export class DaySection {
 	}
 
 	private formatHeader(): string {
-		const format = this.host.plugin.settings.showMonthSeparators
-			? MONTH_SEPARATOR_DAY_FORMAT
-			: this.host.plugin.settings.headerFormat;
-		return this.date.format(format);
+		return this.date.format(this.host.plugin.settings.headerFormat);
 	}
 
 	private relativeLabel(): string | null {

--- a/src/day.ts
+++ b/src/day.ts
@@ -64,6 +64,7 @@ export class DaySection {
 	readonly el: HTMLElement;
 	readonly key: string;
 
+	private yearEl: HTMLElement;
 	private monthEl: HTMLElement;
 	private cardEl: HTMLElement;
 	private headerEl: HTMLElement;
@@ -110,9 +111,15 @@ export class DaySection {
 		this.file = host.plugin.daily.fileFor(date);
 
 		this.el = createDiv({ cls: "journal-day", attr: { "data-date": this.key } });
+		this.yearEl = this.el.createDiv({
+			cls: "journal-year-separator",
+			text: date.format("YYYY"),
+			attr: { role: "heading", "aria-level": "2" },
+		});
+		this.yearEl.hidden = true;
 		this.monthEl = this.el.createDiv({
 			cls: "journal-month-separator",
-			attr: { role: "heading", "aria-level": "2" },
+			attr: { role: "heading", "aria-level": "3" },
 		});
 		this.monthEl.createSpan({ cls: "journal-month-name", text: date.format("MMMM") });
 		this.monthEl.createSpan({ cls: "journal-month-year", text: date.format("YYYY") });
@@ -249,12 +256,12 @@ export class DaySection {
 		return this.el.offsetParent !== null;
 	}
 
-	/** Viewport position of stable day content, below any movable month heading. */
+	/** Viewport position of stable day content, below any movable date headings. */
 	get contentTop(): number {
 		return this.headerEl.getBoundingClientRect().top;
 	}
 
-	/** Card geometry excludes the optional month heading above the day. */
+	/** Card geometry excludes the optional year and month headings above the day. */
 	get cardTop(): number {
 		return this.el.offsetTop + this.cardEl.offsetTop;
 	}
@@ -271,6 +278,12 @@ export class DaySection {
 	/** Shows the month heading carried by the first rendered day in that month. */
 	setMonthSeparator(visible: boolean): void {
 		this.monthEl.hidden = !visible;
+	}
+
+	/** Shows the year heading when this day follows a rendered day in another year. */
+	setYearSeparator(visible: boolean): void {
+		this.yearEl.hidden = !visible;
+		this.el.toggleClass("journal-day-year-start", visible);
 	}
 
 	private formatHeader(): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,7 +198,10 @@ export default class JournalViewPlugin extends Plugin {
 				saved.showMonthSeparators,
 				DEFAULT_SETTINGS.showMonthSeparators,
 			),
-			showYearSeparators: booleanSetting(saved.showYearSeparators, DEFAULT_SETTINGS.showYearSeparators),
+			groupDaysByYear: booleanSetting(
+				saved.groupDaysByYear,
+				booleanSetting(saved.showYearSeparators, DEFAULT_SETTINGS.groupDaysByYear),
+			),
 			saveDelay: saveDelaySetting(saved.saveDelay),
 			richEditor: booleanSetting(saved.richEditor, DEFAULT_SETTINGS.richEditor),
 			focusTodayOnOpen: booleanSetting(saved.focusTodayOnOpen, DEFAULT_SETTINGS.focusTodayOnOpen),

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,6 +198,7 @@ export default class JournalViewPlugin extends Plugin {
 				saved.showMonthSeparators,
 				DEFAULT_SETTINGS.showMonthSeparators,
 			),
+			showYearSeparators: booleanSetting(saved.showYearSeparators, DEFAULT_SETTINGS.showYearSeparators),
 			saveDelay: saveDelaySetting(saved.saveDelay),
 			richEditor: booleanSetting(saved.richEditor, DEFAULT_SETTINGS.richEditor),
 			focusTodayOnOpen: booleanSetting(saved.focusTodayOnOpen, DEFAULT_SETTINGS.focusTodayOnOpen),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting, requireApiVersion } from "obsidian";
-import type { SettingDefinitionItem, TextComponent } from "obsidian";
+import type { SettingDefinitionItem } from "obsidian";
 import type JournalViewPlugin from "./main";
 
 export const MIN_SAVE_DELAY = 200;
@@ -21,8 +21,8 @@ export interface JournalViewSettings {
 	headerFormat: string;
 	/** Show month/year once above a group rather than inside every day. */
 	showMonthSeparators: boolean;
-	/** Show the year when consecutive rendered days cross a year boundary. */
-	showYearSeparators: boolean;
+	/** Group rendered days beneath year boundary headings. */
+	groupDaysByYear: boolean;
 	/** Milliseconds of inactivity before an edited day is written to disk. */
 	saveDelay: number;
 	/** Use Obsidian's own markdown editor inside the journal (live preview). */
@@ -41,7 +41,7 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	templatePath: "",
 	headerFormat: "dddd, D MMMM",
 	showMonthSeparators: false,
-	showYearSeparators: true,
+	groupDaysByYear: true,
 	saveDelay: 600,
 	richEditor: true,
 	focusTodayOnOpen: true,
@@ -56,7 +56,7 @@ type ToggleSettingKey =
 	| "focusTodayOnOpen"
 	| "hideEmptyDays"
 	| "showMonthSeparators"
-	| "showYearSeparators";
+	| "groupDaysByYear";
 
 interface JournalSettingBase {
 	name: string;
@@ -106,8 +106,6 @@ interface LegacySliderTooltip {
 }
 
 export class JournalViewSettingTab extends PluginSettingTab {
-	private headerFormatControl: TextComponent | null = null;
-
 	constructor(app: App, private plugin: JournalViewPlugin) {
 		super(app, plugin);
 	}
@@ -163,25 +161,23 @@ export class JournalViewSettingTab extends PluginSettingTab {
 						},
 					},
 					{
-						name: "Group days by month",
-						desc:
-							"Show month and year once above the first visible day of each month. " +
-							"When off, day headers use the configured date format.",
-						control: { type: "toggle", key: "showMonthSeparators" },
-					},
-					{
-						name: "Show year separators",
-						desc: "Show a centered year heading when consecutive visible days cross a year boundary.",
-						control: { type: "toggle", key: "showYearSeparators" },
-					},
-					{
 						name: "Daily header format",
-						desc: "Moment.js format used for each day when month grouping is off.",
+						desc: "Moment.js format used for each day's header.",
 						control: {
 							type: "text",
 							key: "headerFormat",
 							placeholder: DEFAULT_SETTINGS.headerFormat,
 						},
+					},
+					{
+						name: "Group days by year",
+						desc: "Show a centered year heading when consecutive visible days cross a year boundary.",
+						control: { type: "toggle", key: "groupDaysByYear" },
+					},
+					{
+						name: "Group days by month",
+						desc: "Show month and year once above the first visible day of each month.",
+						control: { type: "toggle", key: "showMonthSeparators" },
 					},
 					{
 						name: "Focus today on open",
@@ -262,7 +258,7 @@ export class JournalViewSettingTab extends PluginSettingTab {
 			case "focusTodayOnOpen":
 			case "hideEmptyDays":
 			case "showMonthSeparators":
-			case "showYearSeparators":
+			case "groupDaysByYear":
 				if (typeof value === "boolean") {
 					this.plugin.settings[key] = value;
 					changed = true;
@@ -274,7 +270,6 @@ export class JournalViewSettingTab extends PluginSettingTab {
 
 	display(): void {
 		const { containerEl } = this;
-		this.headerFormatControl = null;
 		containerEl.empty();
 		for (const group of this.definitions()) {
 			new Setting(containerEl).setName(group.heading).setHeading();
@@ -295,25 +290,18 @@ export class JournalViewSettingTab extends PluginSettingTab {
 		const control = definition.control;
 		switch (control.type) {
 			case "text":
-				setting.addText((text) => {
-					if (control.key === "headerFormat") this.headerFormatControl = text;
+				setting.addText((text) =>
 					text
 						.setPlaceholder(control.placeholder)
 						.setValue(this.plugin.settings[control.key])
-						.setDisabled(control.key === "headerFormat" && this.plugin.settings.showMonthSeparators)
-						.onChange((value) => this.setControlValue(control.key, value));
-				});
+						.onChange((value) => this.setControlValue(control.key, value)),
+				);
 				break;
 			case "toggle":
 				setting.addToggle((toggle) =>
 					toggle
 						.setValue(this.plugin.settings[control.key])
-						.onChange(async (value) => {
-							await this.setControlValue(control.key, value);
-							if (control.key === "showMonthSeparators") {
-								this.headerFormatControl?.setDisabled(value);
-							}
-						}),
+						.onChange((value) => this.setControlValue(control.key, value)),
 				);
 				break;
 			case "slider":

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,8 @@ export interface JournalViewSettings {
 	headerFormat: string;
 	/** Show month/year once above a group rather than inside every day. */
 	showMonthSeparators: boolean;
+	/** Show the year when consecutive rendered days cross a year boundary. */
+	showYearSeparators: boolean;
 	/** Milliseconds of inactivity before an edited day is written to disk. */
 	saveDelay: number;
 	/** Use Obsidian's own markdown editor inside the journal (live preview). */
@@ -39,6 +41,7 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	templatePath: "",
 	headerFormat: "dddd, D MMMM",
 	showMonthSeparators: false,
+	showYearSeparators: true,
 	saveDelay: 600,
 	richEditor: true,
 	focusTodayOnOpen: true,
@@ -48,7 +51,12 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 
 type SettingKey = keyof JournalViewSettings;
 type TextSettingKey = "dateFormat" | "folder" | "templatePath" | "headerFormat";
-type ToggleSettingKey = "richEditor" | "focusTodayOnOpen" | "hideEmptyDays" | "showMonthSeparators";
+type ToggleSettingKey =
+	| "richEditor"
+	| "focusTodayOnOpen"
+	| "hideEmptyDays"
+	| "showMonthSeparators"
+	| "showYearSeparators";
 
 interface JournalSettingBase {
 	name: string;
@@ -158,8 +166,13 @@ export class JournalViewSettingTab extends PluginSettingTab {
 						name: "Group days by month",
 						desc:
 							"Show month and year once above the first visible day of each month. " +
-							"When off, every day shows its full configured date.",
+							"When off, day headers use the configured date format.",
 						control: { type: "toggle", key: "showMonthSeparators" },
+					},
+					{
+						name: "Show year separators",
+						desc: "Show a centered year heading when consecutive visible days cross a year boundary.",
+						control: { type: "toggle", key: "showYearSeparators" },
 					},
 					{
 						name: "Daily header format",
@@ -249,6 +262,7 @@ export class JournalViewSettingTab extends PluginSettingTab {
 			case "focusTodayOnOpen":
 			case "hideEmptyDays":
 			case "showMonthSeparators":
+			case "showYearSeparators":
 				if (typeof value === "boolean") {
 					this.plugin.settings[key] = value;
 					changed = true;

--- a/src/view.ts
+++ b/src/view.ts
@@ -348,7 +348,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	 */
 	private syncDateSeparators(): void {
 		const showMonths = this.plugin.settings.showMonthSeparators;
-		const showYears = this.plugin.settings.showYearSeparators;
+		const showYears = this.plugin.settings.groupDaysByYear;
 		let previousYear: string | null = null;
 		let previousMonth: string | null = null;
 		for (const section of this.sections) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -348,6 +348,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	 */
 	private syncDateSeparators(): void {
 		const showMonths = this.plugin.settings.showMonthSeparators;
+		const showYears = this.plugin.settings.showYearSeparators;
 		let previousYear: string | null = null;
 		let previousMonth: string | null = null;
 		for (const section of this.sections) {
@@ -358,7 +359,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			}
 			const year = section.date.format("YYYY");
 			const month = section.date.format("YYYY-MM");
-			section.setYearSeparator(previousYear !== null && year !== previousYear);
+			// A year heading marks a boundary between rendered days; the sticky
+			// toolbar supplies context for the first day in the current window.
+			section.setYearSeparator(showYears && previousYear !== null && year !== previousYear);
 			section.setMonthSeparator(showMonths && month !== previousMonth);
 			previousYear = year;
 			previousMonth = month;

--- a/src/view.ts
+++ b/src/view.ts
@@ -342,23 +342,25 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	/**
-	 * Carries each month heading on its first rendered day. Keeping the heading
-	 * inside a day means loading, trimming and scroll anchoring still have one
-	 * layout unit per date. Hidden empty days do not count as month starts.
+	 * Carries date headings on the first rendered day in each group. Keeping the
+	 * headings inside a day means loading, trimming and scroll anchoring still
+	 * have one layout unit per date. Hidden empty days do not count as starts.
 	 */
-	private syncMonthSeparators(): void {
-		if (!this.plugin.settings.showMonthSeparators) {
-			for (const section of this.sections) section.setMonthSeparator(false);
-			return;
-		}
+	private syncDateSeparators(): void {
+		const showMonths = this.plugin.settings.showMonthSeparators;
+		let previousYear: string | null = null;
 		let previousMonth: string | null = null;
 		for (const section of this.sections) {
 			if (section.isHidden) {
+				section.setYearSeparator(false);
 				section.setMonthSeparator(false);
 				continue;
 			}
+			const year = section.date.format("YYYY");
 			const month = section.date.format("YYYY-MM");
-			section.setMonthSeparator(month !== previousMonth);
+			section.setYearSeparator(previousYear !== null && year !== previousYear);
+			section.setMonthSeparator(showMonths && month !== previousMonth);
+			previousYear = year;
 			previousMonth = month;
 		}
 	}
@@ -395,7 +397,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		}
 		if (where === "start") this.sections.unshift(...sections);
 		else this.sections.push(...sections);
-		this.syncMonthSeparators();
+		this.syncDateSeparators();
 		// A day can land inside the editor window on a tall pane.
 		this.editors.schedule();
 		if (this.ready) this.find?.sectionsChanged();
@@ -494,7 +496,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			if (!victims.length) return;
 			this.sections.length -= victims.length;
 			for (const section of victims) this.forget(section);
-			this.syncMonthSeparators();
+			this.syncDateSeparators();
 		} else {
 			for (let i = 0; i < this.sections.length && budget > 0; i++, budget--) {
 				const section = this.sections[i];
@@ -506,7 +508,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			const before = referenceDay.contentTop;
 			this.sections.splice(0, victims.length);
 			for (const section of victims) this.forget(section);
-			this.syncMonthSeparators();
+			this.syncDateSeparators();
 			const delta = referenceDay.contentTop - before;
 			if (delta !== 0) this.scrollEl.scrollTop += delta;
 			this.editors.declareScroll();
@@ -974,7 +976,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		// The caller reloads the real content right after; the day starts
 		// empty and any growth is re-pinned by the resize observer.
 		this.sections.splice(at, 0, section);
-		this.syncMonthSeparators();
+		this.syncDateSeparators();
 		this.byPath.set(section.path, section);
 		if (section.file) this.byPath.set(section.file.path, section);
 		this.resizeObserver?.observe(section.el);
@@ -996,7 +998,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		if (previousPath) this.byPath.delete(previousPath);
 		this.byPath.set(day.path, day);
 		if (day.file) this.byPath.set(day.file.path, day);
-		this.syncMonthSeparators();
+		this.syncDateSeparators();
 	}
 
 	onDayContentChanged(_day: DaySection): void {
@@ -1019,7 +1021,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			section.revalidate();
 			if (section.path !== before) changed = true;
 		}
-		this.syncMonthSeparators();
+		this.syncDateSeparators();
 		if (changed) this.indexPaths();
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -173,6 +173,31 @@ button.journal-find-button.is-active {
 	transition: background-color 120ms ease-in-out;
 }
 
+.journal-year-separator {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--size-4-3);
+	margin: var(--size-4-6) 0 var(--size-4-5);
+	padding: 0 var(--size-4-3);
+	color: var(--text-normal);
+	font-size: var(--font-ui-medium);
+	font-weight: var(--font-bold);
+	line-height: var(--line-height-tight);
+}
+
+.journal-year-separator[hidden] {
+	display: none;
+}
+
+.journal-year-separator::before,
+.journal-year-separator::after {
+	content: "";
+	height: 1px;
+	background-color: var(--background-modifier-border);
+	flex: 1 1 0;
+}
+
 .journal-month-separator {
 	display: flex;
 	align-items: baseline;
@@ -205,6 +230,12 @@ button.journal-find-button.is-active {
 	color: var(--text-faint);
 	font-size: var(--font-ui-small);
 	font-weight: var(--font-normal);
+}
+
+/* The year already has its own heading at a boundary; avoid repeating it in
+   the month heading immediately below. */
+.journal-day-year-start .journal-month-year {
+	display: none;
 }
 
 .journal-day-header {


### PR DESCRIPTION
## Summary

- add centered year headings when consecutive visible journal days cross a year boundary
- add a default-on Group days by year setting while keeping the daily header format independent of date grouping
- keep the reader’s scroll position stable when date headings move as notes appear or disappear

## Verification

- npm run typecheck
- npm run lint
- npm run build
- Obsidian test vault: verified the filtered 2026/1914 boundary, year-group toggle, month grouping with a custom daily header format, and pinned-day heading movement