### PR TITLE
Move journal controls into the native header

### DIFF
--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -16,6 +16,7 @@ function applyIcon(el: HTMLElement, ...names: string[]): void {
 /** What the toolbar's controls ask the view to do. */
 export interface ToolbarActions {
 	onToggleFilter(): void;
+	onShowFind(): void;
 	onGoToDate(): void;
 	onGoToToday(): void;
 }
@@ -44,6 +45,14 @@ export class JournalToolbar {
 			});
 			this.filterButton.addEventListener("click", () => actions.onToggleFilter());
 			this.buttons.push(this.filterButton);
+
+			const findButton = buttons.createEl("button", {
+				cls: "clickable-icon journal-toolbar-button",
+			});
+			applyIcon(findButton, "search");
+			setTooltip(findButton, "Find in journal");
+			findButton.addEventListener("click", () => actions.onShowFind());
+			this.buttons.push(findButton);
 
 			const dateButton = buttons.createEl("button", {
 				cls: "clickable-icon journal-toolbar-button journal-toolbar-labeled-button",
@@ -78,6 +87,12 @@ export class JournalToolbar {
 		applyIcon(dateButton, "calendar-search", "calendar-days", "calendar");
 		setTooltip(dateButton, "Go to date");
 		this.buttons.push(dateButton);
+
+		const findButton = view.addAction("search", "Find in journal", () => actions.onShowFind());
+		findButton.addClass("journal-toolbar-button");
+		applyIcon(findButton, "search");
+		setTooltip(findButton, "Find in journal");
+		this.buttons.push(findButton);
 
 		this.filterButton = view.addAction("filter", "Filter days", () => actions.onToggleFilter());
 		this.filterButton.addClass("journal-toolbar-button");

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -81,6 +81,9 @@ export class JournalToolbar {
 
 		this.filterButton = view.addAction("filter", "Filter days", () => actions.onToggleFilter());
 		this.filterButton.addClass("journal-toolbar-button");
+		// Filter describes what the journal shows, so keep it with the navigation
+		// controls rather than the date destinations on the right.
+		view.containerEl.querySelector(".view-header-left")?.appendChild(this.filterButton);
 		this.buttons.push(this.filterButton);
 	}
 

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -1,4 +1,4 @@
-import { setIcon, setTooltip } from "obsidian";
+import { ItemView, Platform, setIcon, setTooltip } from "obsidian";
 
 /**
  * Sets the first icon this Obsidian build actually ships. `setIcon` leaves the
@@ -21,41 +21,72 @@ export interface ToolbarActions {
 }
 
 /**
- * The strip above the journal: where the reader currently is, and the controls
- * that act on the view as a whole. It owns no state of its own - the view tells
- * it what to display.
+ * The journal's header: native and compact on desktop, or the original second
+ * row on mobile. It owns no state of its own - the view tells it what to
+ * display.
  */
 export class JournalToolbar {
-	private toolbarEl: HTMLElement;
-	private labelEl: HTMLElement;
+	private toolbarEl: HTMLElement | null = null;
+	private labelEl: HTMLElement | null = null;
+	private buttons: HTMLElement[] = [];
 	private filterButton: HTMLElement;
+	private readonly mobile = Platform.isMobile;
 
-	constructor(parent: HTMLElement, actions: ToolbarActions) {
-		const toolbar = (this.toolbarEl = parent.createDiv({ cls: "journal-toolbar" }));
-		this.labelEl = toolbar.createDiv({ cls: "journal-toolbar-label", text: "Journal" });
-		const buttons = toolbar.createDiv({ cls: "journal-toolbar-actions" });
+	constructor(private view: ItemView, actions: ToolbarActions) {
+		if (this.mobile) {
+			view.containerEl.addClass("journal-view-mobile");
+			const toolbar = (this.toolbarEl = view.contentEl.createDiv({ cls: "journal-toolbar" }));
+			this.labelEl = toolbar.createDiv({ cls: "journal-toolbar-label", text: "Journal" });
+			const buttons = toolbar.createDiv({ cls: "journal-toolbar-actions" });
 
-		this.filterButton = buttons.createEl("button", { cls: "clickable-icon journal-toolbar-button" });
-		this.filterButton.addEventListener("click", () => actions.onToggleFilter());
+			this.filterButton = buttons.createEl("button", {
+				cls: "clickable-icon journal-toolbar-button",
+			});
+			this.filterButton.addEventListener("click", () => actions.onToggleFilter());
+			this.buttons.push(this.filterButton);
 
-		const dateButton = buttons.createEl("button", {
-			cls: "clickable-icon journal-toolbar-button journal-toolbar-labeled-button",
-		});
-		applyIcon(dateButton, "calendar-search", "calendar-days", "calendar");
-		dateButton.createSpan({ text: "Go to" });
-		setTooltip(dateButton, "Go to date");
-		dateButton.addEventListener("click", () => actions.onGoToDate());
+			const dateButton = buttons.createEl("button", {
+				cls: "clickable-icon journal-toolbar-button journal-toolbar-labeled-button",
+			});
+			applyIcon(dateButton, "calendar-search", "calendar-days", "calendar");
+			dateButton.createSpan({ text: "Go to" });
+			setTooltip(dateButton, "Go to date");
+			dateButton.addEventListener("click", () => actions.onGoToDate());
+			this.buttons.push(dateButton);
 
-		const todayButton = buttons.createEl("button", {
-			cls: "clickable-icon journal-toolbar-button journal-toolbar-labeled-button",
-		});
+			const todayButton = buttons.createEl("button", {
+				cls: "clickable-icon journal-toolbar-button journal-toolbar-labeled-button",
+			});
+			applyIcon(todayButton, "calendar-plus", "calendar-check");
+			todayButton.createSpan({ text: "Today" });
+			setTooltip(todayButton, "Go to today");
+			todayButton.addEventListener("click", () => actions.onGoToToday());
+			this.buttons.push(todayButton);
+			return;
+		}
+
+		// ItemView inserts each native action before the existing ones, so build
+		// these right-to-left to retain the toolbar's visual order beside More.
+		const todayButton = view.addAction("calendar-check", "Go to today", () => actions.onGoToToday());
+		todayButton.addClass("journal-toolbar-button");
 		applyIcon(todayButton, "calendar-plus", "calendar-check");
-		todayButton.createSpan({ text: "Today" });
 		setTooltip(todayButton, "Go to today");
-		todayButton.addEventListener("click", () => actions.onGoToToday());
+		this.buttons.push(todayButton);
+
+		const dateButton = view.addAction("calendar", "Go to date", () => actions.onGoToDate());
+		dateButton.addClass("journal-toolbar-button");
+		applyIcon(dateButton, "calendar-search", "calendar-days", "calendar");
+		setTooltip(dateButton, "Go to date");
+		this.buttons.push(dateButton);
+
+		this.filterButton = view.addAction("filter", "Filter days", () => actions.onToggleFilter());
+		this.filterButton.addClass("journal-toolbar-button");
+		this.buttons.push(this.filterButton);
 	}
 
 	setLabel(text: string): void {
+		this.labelEl ??= this.view.containerEl.querySelector<HTMLElement>(".view-header-title");
+		if (!this.labelEl) return;
 		// This runs every frame while scrolling; only touch the DOM on a change.
 		if (this.labelEl.getText() !== text) this.labelEl.setText(text);
 	}
@@ -68,6 +99,18 @@ export class JournalToolbar {
 	}
 
 	setVisible(visible: boolean): void {
-		this.toolbarEl.toggleClass("is-hidden", !visible);
+		// On mobile the find bar replaces the plugin-owned second row. Desktop
+		// actions live in Obsidian's persistent header and should not jump around.
+		this.toolbarEl?.toggleClass("is-hidden", !visible);
+	}
+
+	destroy(): void {
+		for (const button of this.buttons) button.remove();
+		this.buttons = [];
+		this.toolbarEl?.remove();
+		this.toolbarEl = null;
+		this.view.containerEl.removeClass("journal-view-mobile");
+		if (!this.mobile && this.labelEl?.isConnected) this.labelEl.setText(this.view.getDisplayText());
+		this.labelEl = null;
 	}
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -145,7 +145,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.contentEl.empty();
 		this.contentEl.addClass("journal-content");
 
-		this.toolbar = new JournalToolbar(this.contentEl, {
+		this.toolbar = new JournalToolbar(this, {
 			onToggleFilter: () => void this.toggleHideEmptyDays(),
 			onGoToDate: () => this.openDatePicker(),
 			onGoToToday: () => this.goToToday(true),
@@ -177,6 +177,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.picker?.close();
 		this.find?.destroy();
 		this.find = undefined;
+		this.toolbar?.destroy();
+		this.toolbar = undefined;
 		await this.flushAll();
 		this.teardown();
 	}

--- a/src/view.ts
+++ b/src/view.ts
@@ -863,7 +863,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	private updateHeaderLabel(): void {
 		if (!this.ready || !this.toolbar) return;
-		// The first day at the viewport top determines the sticky month. The
+		// The first day at the viewport top determines the sticky group label. The
 		// indexed lookup skips filtered days, falls back to the first day in top
 		// padding, and retains the last day in bottom padding.
 		const at = findAnchorIndex(
@@ -875,7 +875,10 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			this.scrollEl.scrollTop,
 		);
 		const section = at >= 0 ? this.sections[at] : this.anchoring.section;
-		this.toolbar.setLabel(section ? section.date.format("MMMM YYYY") : "Journal");
+		let label = "Journal";
+		if (section && this.plugin.settings.showMonthSeparators) label = section.date.format("MMMM YYYY");
+		else if (section && this.plugin.settings.groupDaysByYear) label = section.date.format("YYYY");
+		this.toolbar.setLabel(label);
 	}
 
 	/* -------------------------------------------------------- vault events */

--- a/src/view.ts
+++ b/src/view.ts
@@ -147,6 +147,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 		this.toolbar = new JournalToolbar(this, {
 			onToggleFilter: () => void this.toggleHideEmptyDays(),
+			onShowFind: () => this.showFind(),
 			onGoToDate: () => this.openDatePicker(),
 			onGoToToday: () => this.goToToday(true),
 		});

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,37 @@
 
 /* ------------------------------------------------------------- toolbar --- */
 
+.journal-view:not(.journal-view-mobile) .view-header {
+	position: relative;
+	container: journal-header / inline-size;
+	border-bottom: 1px solid var(--divider-color);
+}
+
+.journal-view:not(.journal-view-mobile) .view-header-title-container {
+	position: absolute;
+	inset-inline-start: 50%;
+	inset-block-start: 50%;
+	width: max-content;
+	max-width: 100%;
+	min-width: 0;
+	transform: translate(-50%, -50%);
+}
+
+.journal-view:not(.journal-view-mobile) .view-actions {
+	margin-inline-start: auto;
+}
+
+/* The query sees the header's content box; 30.5rem plus its 1.5rem horizontal
+   padding preserves the 32rem pane breakpoint. */
+@container journal-header (max-width: 30.5rem) {
+	.journal-view:not(.journal-view-mobile) .view-header-title-container {
+		position: static;
+		width: auto;
+		max-width: none;
+		transform: none;
+	}
+}
+
 .journal-toolbar {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## Summary

- Move the desktop month/year title and journal actions into Obsidian’s native header
- Keep the title centered, grouping-aware, responsive, and theme-aligned
- Place Filter with navigation and add icon-only Find, Go to date, and Today actions
- Preserve the original labeled two-row toolbar on mobile
- Remove native actions cleanly when the view closes

## Verification

- npm run typecheck
- npm run lint
- npm run build
- Exercised the desktop header live in test-vault, including action order and Find behavior
- Verified exact title centering, the 512px responsive fallback, and no control overlap
- Verified all four year/month grouping title combinations
- Verified the mobile-scoped toolbar markup, labels, separator, and flexible native header