### PR TITLE
Refine day delete action hover

### DIFF
--- a/src/day.ts
+++ b/src/day.ts
@@ -67,6 +67,7 @@ export class DaySection {
 	private monthEl: HTMLElement;
 	private cardEl: HTMLElement;
 	private headerEl: HTMLElement;
+	private titleEl: HTMLElement;
 	private actionsEl: HTMLElement;
 	private bodyEl: HTMLElement;
 
@@ -125,10 +126,10 @@ export class DaySection {
 		this.monthEl.hidden = true;
 		this.cardEl = this.el.createDiv({ cls: "journal-day-card" });
 		this.headerEl = this.cardEl.createDiv({ cls: "journal-day-header" });
-		const titleEl = this.headerEl.createDiv({ cls: "journal-day-title" });
-		titleEl.createSpan({ cls: "journal-day-date", text: this.formatHeader() });
+		this.titleEl = this.headerEl.createDiv({ cls: "journal-day-title" });
+		this.titleEl.createSpan({ cls: "journal-day-date", text: this.formatHeader() });
 		const relative = this.relativeLabel();
-		if (relative) titleEl.createSpan({ cls: "journal-day-badge", text: relative });
+		if (relative) this.titleEl.createSpan({ cls: "journal-day-badge", text: relative });
 		this.actionsEl = this.headerEl.createDiv({ cls: "journal-day-actions" });
 
 		this.bodyEl = this.cardEl.createDiv({ cls: "journal-day-body" });
@@ -305,10 +306,12 @@ export class DaySection {
 
 		this.bodyEl.dataset.placeholder = this.exists ? "Empty note" : "Start typing to create this note";
 		this.actionsEl.empty();
-		setTooltip(this.headerEl, this.path, { placement: "right" });
+		setTooltip(this.titleEl, this.path, { placement: "right" });
 
 		if (this.exists) {
-			const remove = this.actionsEl.createEl("button", { cls: "clickable-icon journal-day-action" });
+			const remove = this.actionsEl.createEl("button", {
+				cls: "clickable-icon journal-day-action journal-day-delete",
+			});
 			setIcon(remove, "trash-2");
 			setTooltip(remove, "Delete note");
 			remove.addEventListener("click", (event) => {

--- a/styles.css
+++ b/styles.css
@@ -318,8 +318,25 @@ button.journal-find-button.is-active {
 }
 
 .journal-day:hover .journal-day-actions,
-.journal-day-focused .journal-day-actions {
+.journal-day-focused .journal-day-actions,
+.journal-day-actions:focus-within {
 	opacity: 1;
+}
+
+/* With a hover-capable pointer, keep the destructive action tied to the header
+   rather than the much larger day hover target. Focus always reveals it. */
+@media (hover: hover) {
+	button.journal-day-delete {
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 120ms ease-in-out;
+	}
+
+	.journal-day-header:hover button.journal-day-delete,
+	button.journal-day-delete:focus {
+		opacity: 1;
+		pointer-events: auto;
+	}
 }
 
 button.journal-day-create {


### PR DESCRIPTION
## Summary

- Show Delete only while hovering the day header on hover-capable devices
- Keep Open Note available on whole-day hover and preserve keyboard and touch access
- Scope the journal path tooltip to the day title so it no longer competes with action tooltips

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test-vault`
- Obsidian test vault: checked body hover, header hover, Shift-Tab focus, cancelled-delete focus restoration, touch emulation, and Delete/Open tooltip text