### PR TITLE
Match Obsidian's own autosave delay, and group the advanced settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ vault handles daily notes.
 | Focus today on open | On | Opens the journal at today's note and places the cursor there |
 | Only show days that have a note | On | Skips empty days while always keeping today visible; turn it off to show every day |
 | Rich editor | On | Uses Obsidian's Markdown editor; turn it off to use the plain-text fallback |
-| Autosave delay | 600 ms | Sets how long Journal View waits after typing before saving |
+| Autosave delay | 2000 ms | Sets how long Journal View waits after typing before saving |
 
 ## Privacy
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,7 +42,9 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	headerFormat: "dddd, D MMMM",
 	showMonthSeparators: false,
 	groupDaysByYear: true,
-	saveDelay: 600,
+	// Obsidian debounces its own `TextFileView.requestSave` by the same amount,
+	// so an edited day reaches disk as often as the note would in a normal pane.
+	saveDelay: 2000,
 	richEditor: true,
 	focusTodayOnOpen: true,
 	hideEmptyDays: true,
@@ -202,11 +204,13 @@ export class JournalViewSettingTab extends PluginSettingTab {
 			},
 			{
 				type: "group",
-				heading: "Performance",
+				heading: "Advanced",
 				items: [
 					{
 						name: "Autosave delay",
-						desc: "Milliseconds of inactivity before an edited day is written to disk.",
+						desc:
+							"Milliseconds of inactivity before an edited day is written to disk. " +
+							"Leaving a day always saves it at once.",
 						control: {
 							type: "slider",
 							key: "saveDelay",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -193,6 +193,12 @@ export class JournalViewSettingTab extends PluginSettingTab {
 							"Today is always shown. When off, every day appears, faded until you type in it.",
 						control: { type: "toggle", key: "hideEmptyDays" },
 					},
+				],
+			},
+			{
+				type: "group",
+				heading: "Advanced",
+				items: [
 					{
 						name: "Rich editor",
 						desc:
@@ -200,12 +206,6 @@ export class JournalViewSettingTab extends PluginSettingTab {
 							"Turn off to fall back to a plain text editor.",
 						control: { type: "toggle", key: "richEditor" },
 					},
-				],
-			},
-			{
-				type: "group",
-				heading: "Advanced",
-				items: [
 					{
 						name: "Autosave delay",
 						desc:


### PR DESCRIPTION
## What changed

**Autosave delay.** Journal View wrote an edited day 600 ms after typing stopped. Obsidian debounces its own `TextFileView.requestSave` by 2 seconds, so a day in the journal hit disk more often than the same note would in a normal editor pane — for a number nobody had a reason to pick.

- `DEFAULT_SETTINGS.saveDelay` is now `2000`, matching Obsidian.
- The setting stays, and the slider keeps its 200–3000 range. Its description now says that leaving a day saves it at once.
- No migration: a vault with a stored delay keeps whatever it has, so the new default only reaches installs that have never saved settings.

**Advanced group.** The **Performance** group is renamed **Advanced**, and **Rich editor** moves into it from **Display**. Which editor implementation backs a day is a choice about how the plugin works rather than how the journal looks, and it belongs next to the other setting nobody needs to touch — both are there for when the embedded editor has to be worked around.

## User-visible effect

On a fresh install an edited day is written 2 s after you stop typing instead of 0.6 s; leaving a day still saves it immediately. Existing vaults keep their stored value and can move to 2000 with the slider. Settings → Journal View now reads **Daily notes** / **Display** / **Advanced**, with Rich editor and Autosave delay under Advanced.

## Verification

`npm run typecheck` and `npm run build` pass. Exercised in `test-vault` with the plugin reloaded onto the new build:

- Loading, by editing `data.json` and reloading the plugin: no stored value → `2000`; stored `600` → `600`.
- The delay actually handed to the save timer, captured by spying on `setTimeout` inside `scheduleSave`: setting `2000` → `2000`, setting `700` → `700`.
- End-to-end write timing at the default: a doc change scheduled a save at 1 ms and the vault write went out at 2022 ms. Timings below ~1 s are not meaningful from a script — Chromium aligns timers to whole seconds while the Obsidian window is in the background, so a 300 ms setting reads as ~1000 ms. That is why the per-setting check above reads the timer argument instead of the clock.
- Rendered groups are `Daily notes` → `[Current configuration, Date format, Folder, Template]`, `Display` → `[Day order, Daily header format, Group days by year, Group days by month, Focus today on open, Only show days that have a note]`, `Advanced` → `[Rich editor, Autosave delay]`, with the slider showing 2000 (min 200, max 3000, step 100).
- Clicking Rich editor in its new home flipped `settings.richEditor` to false and swapped every live day onto the plain-text editor, and clicking it again restored the rich editors.

Note for reviewers: on Obsidian 1.13+ the tab is rendered from `getSettingDefinitions()`, not from our `display()` override, which is now only the path for the 1.7.2–1.12 range in `minAppVersion`. Both read the same definitions, so both get the regrouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
