### PR TITLE
Fix live embed and external note refresh

### DIFF
--- a/src/day.ts
+++ b/src/day.ts
@@ -39,6 +39,11 @@ function noteBody(content: string): string {
 	return content.slice(getFrontMatterInfo(content).contentStart);
 }
 
+/** CodeMirror stores every line break as `\n`, regardless of the file's EOL. */
+function editorBody(content: string): string {
+	return noteBody(content).replace(/\r\n?/g, "\n");
+}
+
 function replaceNoteBody(content: string, body: string): string {
 	return content.slice(0, getFrontMatterInfo(content).contentStart) + body;
 }
@@ -99,6 +104,8 @@ export class DaySection {
 	private endReveal: (() => void) | null = null;
 
 	private lastKnownContent = "";
+	/** An external write held off until this day's own pending edit has settled. */
+	private externalReloadPending = false;
 	/** Template text shown in an empty day but not yet accepted by the reader. */
 	private pendingTemplate: string | null = null;
 	private saveTimer = 0;
@@ -212,7 +219,7 @@ export class DaySection {
 	 */
 	private async offerTemplate(): Promise<void> {
 		if (this.file || !this.editor || this.editor.getValue().length > 0) return;
-		const body = noteBody(await this.host.plugin.daily.templateContent(this.date));
+		const body = editorBody(await this.host.plugin.daily.templateContent(this.date));
 		// Reading the template yields, so everything above is re-checked: the
 		// reader may have typed, left, or the note may have appeared, in
 		// between. An offer landing after they left would have nothing to
@@ -240,11 +247,10 @@ export class DaySection {
 		}
 
 		this.pendingTemplate = null;
-		this.editor.setValue(noteBody(this.lastKnownContent));
+		this.editor.setValue(editorBody(this.lastKnownContent));
 		this.updateBlankState();
-		// A note can appear under an offer that is still standing - Sync, or
-		// another view. Its content was held off while the day had focus, so
-		// the day asks for it now rather than saving the offer over it.
+		// A note can appear between offering the template and this blur. Re-read
+		// it rather than leave the pre-offer content in the editor.
 		if (this.file) void this.reload();
 		return true;
 	}
@@ -407,12 +413,12 @@ export class DaySection {
 		// An untouched template offer is not the reader's work, so it must not
 		// pin the day to edit mode or fend off content arriving from the vault.
 		if (value === this.pendingTemplate) return false;
-		return value !== noteBody(this.lastKnownContent);
+		return value !== editorBody(this.lastKnownContent);
 	}
 
 	/** The body as the reader sees it, including edits not yet written to disk. */
 	searchText(): string {
-		return this.editor?.getValue() ?? noteBody(this.lastKnownContent);
+		return this.editor?.getValue() ?? editorBody(this.lastKnownContent);
 	}
 
 	setFindState(
@@ -603,7 +609,7 @@ export class DaySection {
 		this.bodyEl.empty();
 		if (this.heldHeight > 0) this.bodyEl.setCssProps({ "--journal-held-height": `${this.heldHeight}px` });
 		this.el.addClass("journal-day-editing");
-		const body = noteBody(this.lastKnownContent);
+		const body = editorBody(this.lastKnownContent);
 		const placeholder = this.exists ? "Empty note" : "Start typing to create this note";
 		const token = this.modeToken;
 		try {
@@ -783,19 +789,27 @@ export class DaySection {
 	applyExternalContent(content: string): void {
 		if (!this.editor) {
 			this.lastKnownContent = content;
+			this.externalReloadPending = false;
 			this.host.onDayContentChanged(this);
 			return;
 		}
-		const body = noteBody(content);
+		const body = editorBody(content);
 		if (this.editor.getValue() === body) {
 			this.lastKnownContent = content;
+			this.externalReloadPending = false;
 			return;
 		}
-		if (this.hasFocus || this.isDirty) return; // never clobber the user's typing
+		if (this.isDirty) {
+			// A metadata event held off by our pending save is not replayed. Retry
+			// once the queue settles so the editor reflects whichever write won.
+			this.externalReloadPending = true;
+			return;
+		}
 
 		this.pendingTemplate = null;
-		this.editor.setValue(body);
+		this.editor.setValue(body, true);
 		this.lastKnownContent = content;
+		this.externalReloadPending = false;
 		// The held height belongs to content that is no longer what the day
 		// holds; the editor's own height is the honest one now.
 		this.releaseHeight();
@@ -804,8 +818,8 @@ export class DaySection {
 	}
 
 	/** Brings the day up to date with the note's current content on disk. */
-	async reload(): Promise<void> {
-		const content = await this.readContent();
+	async reload(knownContent?: string): Promise<void> {
+		const content = knownContent ?? (await this.readContent());
 		if (this.destroyed) return;
 		if (this.editor) {
 			this.applyExternalContent(content);
@@ -833,13 +847,14 @@ export class DaySection {
 		const body = this.editor.getValue();
 		if (body === this.pendingTemplate) return; // an offer nobody accepted
 		this.pendingTemplate = null;
-		if (body !== noteBody(this.lastKnownContent)) void this.queue.submit(body);
+		if (body !== editorBody(this.lastKnownContent)) void this.queue.submit(body);
 	}
 
 	async flush(): Promise<void> {
 		window.clearTimeout(this.saveTimer);
 		this.capture();
 		await this.queue.settled();
+		if (!this.destroyed && this.externalReloadPending && !this.isDirty) await this.reload();
 	}
 
 	private async writeValue(body: string): Promise<boolean> {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -22,7 +22,8 @@ export interface JournalEditorOptions {
 
 export interface JournalEditor {
 	getValue(): string;
-	setValue(value: string): void;
+	/** Replaces the contents; `preserveSelection` is for a clean external update. */
+	setValue(value: string, preserveSelection?: boolean): void;
 	setFile(file: TFile | null): void;
 	focus(): void;
 	hasFocus(): boolean;
@@ -95,6 +96,7 @@ interface InternalEditorInstance {
 	get?(): string | null;
 	set?(value: string, clear: boolean): void;
 	onUpdate?: (update: unknown, changed: boolean) => void;
+	load?(): void;
 	destroy?(): void;
 	unload?(): void;
 }
@@ -253,6 +255,12 @@ class RichEditor implements JournalEditor {
 			if (changed) this.options.onChange();
 		};
 
+		// The editor is normally added as a child of Obsidian's MarkdownEmbed,
+		// which loads it before assigning content. Constructing it directly skips
+		// that lifecycle unless we do it here. In particular, live-preview embeds
+		// only register their metadata-change listeners once their component tree
+		// is loaded.
+		instance.load?.();
 		this.instance.set?.(options.value, true);
 		this.dropScrollRequest();
 		this.reportInitialLayout();
@@ -304,9 +312,12 @@ class RichEditor implements JournalEditor {
 		}
 	}
 
-	setValue(value: string): void {
+	setValue(value: string, preserveSelection = false): void {
 		try {
-			this.instance?.set?.(value, true);
+			// Obsidian's non-clearing path applies the smallest document change,
+			// mapping the selection through it. Template offers retain the clearing
+			// behavior they have always used; only external updates ask to preserve.
+			this.instance?.set?.(value, !preserveSelection);
 			this.dropScrollRequest();
 		} catch (error) {
 			console.warn("Journal View: could not update editor contents", error);
@@ -510,9 +521,14 @@ class PlainEditor implements JournalEditor {
 		return this.textarea.value;
 	}
 
-	setValue(value: string): void {
+	setValue(value: string, preserveSelection = false): void {
 		if (this.textarea.value === value) return;
+		const selectionStart = this.textarea.selectionStart;
+		const selectionEnd = this.textarea.selectionEnd;
 		this.textarea.value = value;
+		if (preserveSelection && this.hasFocus()) {
+			this.textarea.setSelectionRange(selectionStart, selectionEnd);
+		}
 		this.autoGrow();
 	}
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -915,10 +915,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		);
 
 		this.registerEvent(
-			this.app.vault.on("modify", (file) => {
-				if (!(file instanceof TFile)) return;
+			this.app.metadataCache.on("changed", (file, data) => {
 				const section = this.byPath.get(file.path);
-				if (section?.file?.path === file.path) void section.reload();
+				if (section?.file?.path === file.path) void section.reload(data);
 			}),
 		);
 


### PR DESCRIPTION
## Summary

- Load the borrowed Obsidian editor component lifecycle so live-preview embeds subscribe to metadata changes.
- Refresh daily-note editors from indexed external changes while preserving the cursor and deferring updates during pending saves.
- Keep template reset behavior unchanged and normalize editor-facing line endings to avoid false dirty states.

## User-visible effect

Embedded note previews in Journal View now update when their source note changes. External commands that modify a daily note, such as Rollover Daily Todos, also update a clean Journal View editor without requiring the view to be reopened.

Concurrent body edits remain last-write-wins; this change does not merge conflicting edits.

Addresses #17.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`

Live Obsidian interaction was not completed because the active window moved from the throwaway test vault to a real vault during setup, and testing was stopped without interacting with that vault.