### PR TITLE
Improve long-distance journal navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ vault handles daily notes.
 | Only show days that have a note | On | Skips empty days while always keeping today visible; turn it off to show every day |
 | Rich editor | On | Uses Obsidian's Markdown editor; turn it off to use the plain-text fallback |
 | Autosave delay | 2000 ms | Sets how long Journal View waits after typing before saving |
+| Days kept loaded | 60 | Sets the target number of days kept in the timeline; dropped days reload when you scroll back to them |
 
 ## Privacy
 

--- a/src/day.ts
+++ b/src/day.ts
@@ -703,15 +703,20 @@ export class DaySection {
 		this.el.addClass("journal-day-focused");
 		// Focus is the one signal every way in shares - a click the editor
 		// swallowed, a keyboard tab, or a jump to a date.
+		this.scheduleFocusSettled();
+	}
+
+	private scheduleFocusSettled(): void {
 		const token = ++this.focusSettleToken;
 		void this.reportFocusSettled(token);
 	}
 
-	/** Waits through template insertion and the editor's resulting measurements. */
+	/** Waits through template insertion, editor measurement and cursor reveal. */
 	private async reportFocusSettled(token: number): Promise<void> {
 		await this.offerTemplate();
-		await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
-		await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+		for (let frame = 0; frame < REVEAL_FRAMES + 2; frame++) {
+			await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+		}
 		if (this.destroyed || token !== this.focusSettleToken || !this.hasFocus) return;
 		this.host.onDayFocusSettled(this);
 	}
@@ -747,9 +752,13 @@ export class DaySection {
 		this.mountEditor();
 		if (!this.editor) return;
 		this.editor.focus();
-		if (!atEnd) return;
-		this.editor.placeCursorAtEnd?.(true);
-		this.keepCursorInView();
+		if (atEnd) {
+			this.editor.placeCursorAtEnd?.(true);
+			this.keepCursorInView();
+		}
+		// `focus()` emits nothing when this editor already owns focus. Navigation
+		// still needs a fresh measurement after it has returned from far offscreen.
+		this.scheduleFocusSettled();
 	}
 
 	/**

--- a/src/day.ts
+++ b/src/day.ts
@@ -27,6 +27,8 @@ export interface DayHost {
 	isOffScreen(day: DaySection): boolean;
 	/** Re-indexes find results after this day's visible body changes. */
 	onDayContentChanged(day: DaySection): void;
+	/** Re-centres a navigation after focus-driven editor and template layout settles. */
+	onDayFocusSettled(day: DaySection): void;
 	/** Opens the journal-wide find UI from an embedded editor command. */
 	showFind(): void;
 }
@@ -110,6 +112,8 @@ export class DaySection {
 	private pendingTemplate: string | null = null;
 	private saveTimer = 0;
 	private focused = false;
+	/** Invalidates focus-settle work when focus leaves or the day is destroyed. */
+	private focusSettleToken = 0;
 	private readonly queue = new SaveQueue((value) => this.writeValue(value));
 	private findState: {
 		query: string;
@@ -630,16 +634,7 @@ export class DaySection {
 						this.scheduleSave();
 						this.host.onDayContentChanged(this);
 					},
-					onFocus: () => {
-						this.focused = true;
-						// Measurement should normally have released the guard before
-						// the reader arrives; focus is the defensive fallback.
-						this.releaseHeight();
-						this.el.addClass("journal-day-focused");
-						// Focus is the one signal every way in shares - a click
-						// the editor swallowed, a keyboard tab, a jump to a date.
-						void this.offerTemplate();
-					},
+					onFocus: () => this.onEditorFocus(),
 					onBlur: () => this.onEditorBlur(),
 					onFind: () => this.host.showFind(),
 				},
@@ -700,8 +695,30 @@ export class DaySection {
 		this.bodyEl.setCssProps({ "--journal-held-height": "0px" });
 	}
 
+	private onEditorFocus(): void {
+		this.focused = true;
+		// Measurement should normally have released the guard before the
+		// reader arrives; focus is the defensive fallback.
+		this.releaseHeight();
+		this.el.addClass("journal-day-focused");
+		// Focus is the one signal every way in shares - a click the editor
+		// swallowed, a keyboard tab, or a jump to a date.
+		const token = ++this.focusSettleToken;
+		void this.reportFocusSettled(token);
+	}
+
+	/** Waits through template insertion and the editor's resulting measurements. */
+	private async reportFocusSettled(token: number): Promise<void> {
+		await this.offerTemplate();
+		await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+		await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+		if (this.destroyed || token !== this.focusSettleToken || !this.hasFocus) return;
+		this.host.onDayFocusSettled(this);
+	}
+
 	/** Blurring an editor is not leaving the day, but it is a good time to save. */
 	private onEditorBlur(): void {
+		this.focusSettleToken++;
 		this.focused = false;
 		this.el.removeClass("journal-day-focused");
 		// Leaving a day the reader only looked at costs them nothing.
@@ -914,6 +931,7 @@ export class DaySection {
 
 	destroy(): void {
 		this.destroyed = true;
+		this.focusSettleToken++;
 		window.clearTimeout(this.saveTimer);
 		this.stopRevealing();
 		// Anything unsaved goes to the queue, which outlives this object.

--- a/src/day.ts
+++ b/src/day.ts
@@ -5,15 +5,13 @@ import type { Moment } from "./moment";
 import { SaveQueue } from "./saveQueue";
 import { findLiteralRanges } from "./findText";
 import type { FindRange } from "./findText";
+import { listenForReaderScrollIntent } from "./readerInput";
 
 /**
  * Frames a cursor placed at the end of a day is kept on screen for, long
  * enough to outlast the centring and the rebuild that can follow a go-to.
  */
 const REVEAL_FRAMES = 10;
-/** The reader moving the journal themselves, which ends that hold at once. */
-const READER_SCROLL_EVENTS = ["wheel", "touchmove", "pointerdown"] as const;
-const REVEAL_LISTENER: AddEventListenerOptions = { capture: true, passive: true };
 
 /** The bits of the journal view a day needs to talk to. */
 export interface DayHost {
@@ -747,10 +745,11 @@ export class DaySection {
 	 * and coming home to it. Every other way in leaves the cursor where focus
 	 * put it: a day reached by date is one to read as much as to write in, and
 	 * find needs the cursor on the match it just revealed.
+	 * Returns false when the guarded editor mount failed.
 	 */
-	focusEditor(atEnd = false): void {
+	focusEditor(atEnd = false): boolean {
 		this.mountEditor();
-		if (!this.editor) return;
+		if (!this.editor) return false;
 		this.editor.focus();
 		if (atEnd) {
 			this.editor.placeCursorAtEnd?.(true);
@@ -759,6 +758,7 @@ export class DaySection {
 		// `focus()` emits nothing when this editor already owns focus. Navigation
 		// still needs a fresh measurement after it has returned from far offscreen.
 		this.scheduleFocusSettled();
+		return true;
 	}
 
 	/**
@@ -780,10 +780,7 @@ export class DaySection {
 		this.stopRevealing();
 		const scroller: EventTarget = this.el.closest(".journal-scroll") ?? this.el.ownerDocument;
 		const surrender = (): void => this.stopRevealing(true);
-		for (const type of READER_SCROLL_EVENTS) scroller.addEventListener(type, surrender, REVEAL_LISTENER);
-		this.endReveal = () => {
-			for (const type of READER_SCROLL_EVENTS) scroller.removeEventListener(type, surrender, REVEAL_LISTENER);
-		};
+		this.endReveal = listenForReaderScrollIntent(scroller, surrender);
 
 		let frames = REVEAL_FRAMES;
 		const step = (): void => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
 	JournalViewSettings,
 	LEGACY_FULL_HEADER_FORMAT,
 	MONTH_SEPARATOR_DAY_FORMAT,
+	clampLoadedDays,
 	clampSaveDelay,
 } from "./settings";
 import type { DaySortDirection } from "./settings";
@@ -203,6 +204,7 @@ export default class JournalViewPlugin extends Plugin {
 				booleanSetting(saved.showYearSeparators, DEFAULT_SETTINGS.groupDaysByYear),
 			),
 			saveDelay: saveDelaySetting(saved.saveDelay),
+			maxLoadedDays: loadedDaysSetting(saved.maxLoadedDays),
 			richEditor: booleanSetting(saved.richEditor, DEFAULT_SETTINGS.richEditor),
 			focusTodayOnOpen: booleanSetting(saved.focusTodayOnOpen, DEFAULT_SETTINGS.focusTodayOnOpen),
 			hideEmptyDays: booleanSetting(saved.hideEmptyDays, DEFAULT_SETTINGS.hideEmptyDays),
@@ -237,6 +239,11 @@ function headerFormatSetting(value: unknown, hasGroupingSetting: boolean): strin
 function saveDelaySetting(value: unknown): number {
 	if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_SETTINGS.saveDelay;
 	return clampSaveDelay(value);
+}
+
+function loadedDaysSetting(value: unknown): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_SETTINGS.maxLoadedDays;
+	return clampLoadedDays(value);
 }
 
 function booleanSetting(value: unknown, fallback: boolean): boolean {

--- a/src/readerInput.ts
+++ b/src/readerInput.ts
@@ -1,0 +1,23 @@
+/** Pointer and touch gestures that mean the reader has taken over scrolling. */
+const READER_SCROLL_EVENTS = ["wheel", "touchmove", "pointerdown"] as const;
+/** Keyboard gestures that can move the journal or its focused editor. */
+const READER_SCROLL_KEYS = new Set(["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "]);
+const READER_SCROLL_LISTENER: AddEventListenerOptions = { capture: true, passive: true };
+
+/**
+ * Watches the ways a reader can take over a programmatic scroll hold.
+ * Returns one cleanup so cursor reveal and view centring use exactly the same
+ * definition of reader input.
+ */
+export function listenForReaderScrollIntent(target: EventTarget, callback: () => void): () => void {
+	const onScroll = (): void => callback();
+	const onKeydown = (event: Event): void => {
+		if (event instanceof KeyboardEvent && READER_SCROLL_KEYS.has(event.key)) callback();
+	};
+	for (const type of READER_SCROLL_EVENTS) target.addEventListener(type, onScroll, READER_SCROLL_LISTENER);
+	target.addEventListener("keydown", onKeydown, READER_SCROLL_LISTENER);
+	return () => {
+		for (const type of READER_SCROLL_EVENTS) target.removeEventListener(type, onScroll, READER_SCROLL_LISTENER);
+		target.removeEventListener("keydown", onKeydown, READER_SCROLL_LISTENER);
+	};
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,9 @@ import type JournalViewPlugin from "./main";
 export const MIN_SAVE_DELAY = 200;
 export const MAX_SAVE_DELAY = 3000;
 const SAVE_DELAY_STEP = 100;
+export const MIN_LOADED_DAYS = 20;
+export const MAX_LOADED_DAYS = 120;
+const LOADED_DAYS_STEP = 5;
 export const MONTH_SEPARATOR_DAY_FORMAT = "dddd, D";
 export const LEGACY_FULL_HEADER_FORMAT = "dddd, D MMMM YYYY";
 
@@ -25,6 +28,8 @@ export interface JournalViewSettings {
 	groupDaysByYear: boolean;
 	/** Milliseconds of inactivity before an edited day is written to disk. */
 	saveDelay: number;
+	/** Target maximum number of day sections kept in the timeline. */
+	maxLoadedDays: number;
 	/** Use Obsidian's own markdown editor inside the journal (live preview). */
 	richEditor: boolean;
 	/** Put the cursor in today's note when the view opens. */
@@ -45,6 +50,7 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	// Obsidian debounces its own `TextFileView.requestSave` by the same amount,
 	// so an edited day reaches disk as often as the note would in a normal pane.
 	saveDelay: 2000,
+	maxLoadedDays: 60,
 	richEditor: true,
 	focusTodayOnOpen: true,
 	hideEmptyDays: true,
@@ -79,7 +85,13 @@ interface JournalToggleSetting extends JournalSettingBase {
 }
 
 interface JournalSliderSetting extends JournalSettingBase {
-	control: { type: "slider"; key: "saveDelay"; min: number; max: number; step: number };
+	control: {
+		type: "slider";
+		key: "saveDelay" | "maxLoadedDays";
+		min: number;
+		max: number;
+		step: number;
+	};
 }
 
 interface JournalDropdownSetting extends JournalSettingBase {
@@ -219,6 +231,19 @@ export class JournalViewSettingTab extends PluginSettingTab {
 							step: SAVE_DELAY_STEP,
 						},
 					},
+					{
+						name: "Days kept loaded",
+						desc:
+							"Target maximum number of days kept in the timeline. Lower values use less memory " +
+							"but reload days sooner. Focused and nearby days may temporarily exceed the target.",
+						control: {
+							type: "slider",
+							key: "maxLoadedDays",
+							min: MIN_LOADED_DAYS,
+							max: MAX_LOADED_DAYS,
+							step: LOADED_DAYS_STEP,
+						},
+					},
 				],
 			},
 		];
@@ -249,6 +274,12 @@ export class JournalViewSettingTab extends PluginSettingTab {
 			case "saveDelay":
 				if (typeof value === "number" && Number.isFinite(value)) {
 					this.plugin.settings[key] = clampSaveDelay(value);
+					changed = true;
+				}
+				break;
+			case "maxLoadedDays":
+				if (typeof value === "number" && Number.isFinite(value)) {
+					this.plugin.settings[key] = clampLoadedDays(value);
 					changed = true;
 				}
 				break;
@@ -335,6 +366,11 @@ function isSettingKey(key: string): key is keyof JournalViewSettings {
 
 export function clampSaveDelay(value: number): number {
 	return Math.max(MIN_SAVE_DELAY, Math.min(MAX_SAVE_DELAY, value));
+}
+
+export function clampLoadedDays(value: number): number {
+	const clamped = Math.max(MIN_LOADED_DAYS, Math.min(MAX_LOADED_DAYS, value));
+	return Math.round(clamped / LOADED_DAYS_STEP) * LOADED_DAYS_STEP;
 }
 
 function showLegacySliderTooltip(slider: unknown): void {

--- a/src/view.ts
+++ b/src/view.ts
@@ -11,6 +11,7 @@ import { JournalFind, JournalFindHost } from "./find";
 import type { FindRange } from "./findText";
 import { createMoment } from "./moment";
 import type { Moment } from "./moment";
+import { listenForReaderScrollIntent } from "./readerInput";
 
 export const VIEW_TYPE_JOURNAL = "journal-view";
 
@@ -24,9 +25,6 @@ const TRIM_KEEP_RATIO = 0.8;
 const TRIM_DISTANCE = LOAD_THRESHOLD * 2;
 /** Long jumps skip animation once the destination is further away than this many viewports. */
 const SMOOTH_CENTER_VIEWPORTS = 2;
-/** Reader input that cancels a pending post-focus navigation correction. */
-const CENTER_CANCEL_EVENTS = ["wheel", "touchmove", "pointerdown"] as const;
-const CENTER_CANCEL_LISTENER: AddEventListenerOptions = { capture: true, passive: true };
 /** Per-frame scroll step (px) above which the reader is still travelling. */
 const FLICK_STEP = 24;
 /** How long after the last scroll step the view still counts as moving (ms). */
@@ -111,6 +109,10 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private origin = 0;
 	/** A settings change that arrived while a build was in flight. */
 	private settingsPending = false;
+	/** Rebuild-affecting settings used by the current window. */
+	private appliedSettingsSignature = "";
+	/** Loaded-day target already applied without necessarily rebuilding. */
+	private appliedMaxLoadedDays = 0;
 	private configSignature = "";
 	private indexVersion = -1;
 	private initialDate?: Moment;
@@ -235,6 +237,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private async build(around?: Moment, focusToday = false): Promise<void> {
 		this.ready = false;
 		this.centered = false;
+		const settingsSignature = this.rebuildSettingsSignature();
+		const maxLoadedDays = this.plugin.settings.maxLoadedDays;
 		this.today = createMoment().startOf("day");
 		this.configSignature = JSON.stringify(this.plugin.daily.config());
 		this.plugin.index.ensureCurrent();
@@ -291,6 +295,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			return;
 		}
 		this.commit(sections, "end");
+		this.appliedSettingsSignature = settingsSignature;
+		this.appliedMaxLoadedDays = maxLoadedDays;
 
 		this.ready = true;
 		if (this.scrollEl.clientHeight > 0) {
@@ -739,10 +745,11 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	private centerTarget(section: DaySection): number {
-		return Math.max(
+		const target = Math.max(
 			0,
 			section.cardTop - Math.max(0, (this.scrollEl.clientHeight - section.cardHeight) / 2),
 		);
+		return Math.min(target, Math.max(0, this.scrollEl.scrollHeight - this.scrollEl.clientHeight));
 	}
 
 	private centerBehavior(section: DaySection): "instant" | "smooth" {
@@ -758,7 +765,10 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private focusAfterCenter(section: DaySection, atEnd: boolean): void {
 		// Even an editor that retained focus can have stale offscreen measurements.
 		this.armPendingFocusCenter(section);
-		section.focusEditor(atEnd);
+		if (!section.focusEditor(atEnd)) {
+			this.clearPendingFocusCenter();
+			return;
+		}
 		// Cursor reveal registers its frame during focus. Registering this one
 		// afterwards makes the centring correction the last write before paint.
 		this.schedulePendingFocusCenter();
@@ -769,11 +779,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.pendingFocusCenter = section;
 		this.pendingFocusCenterReadyAt = 0;
 		this.pendingFocusCenterStartedAt = performance.now();
-		const cancel = (): void => this.clearPendingFocusCenter();
-		for (const type of CENTER_CANCEL_EVENTS) this.scrollEl.addEventListener(type, cancel, CENTER_CANCEL_LISTENER);
-		this.endPendingFocusCenter = () => {
-			for (const type of CENTER_CANCEL_EVENTS) this.scrollEl.removeEventListener(type, cancel, CENTER_CANCEL_LISTENER);
-		};
+		this.endPendingFocusCenter = listenForReaderScrollIntent(this.scrollEl, () =>
+			this.clearPendingFocusCenter(),
+		);
 	}
 
 	private clearPendingFocusCenter(): void {
@@ -820,7 +828,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		if (!section?.el.isConnected || section.cardHeight > this.scrollEl.clientHeight) return;
 		const target = this.centerTarget(section);
 		if (Math.abs(target - this.scrollEl.scrollTop) < 0.5) return;
+		const before = this.scrollEl.scrollTop;
 		this.scrollEl.scrollTop = target;
+		if (Math.abs(this.scrollEl.scrollTop - before) < 0.5) return;
 		this.editors.declareScroll();
 		this.anchoring.pin();
 		// Stay through a full quiet period after the last correction.
@@ -1173,12 +1183,40 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.toolbar?.setFilter(this.plugin.settings.hideEmptyDays);
 	}
 
+	/** Settings whose existing day DOM cannot adopt safely in place. */
+	private rebuildSettingsSignature(): string {
+		const settings = this.plugin.settings;
+		return JSON.stringify({
+			dateFormat: settings.dateFormat,
+			folder: settings.folder,
+			templatePath: settings.templatePath,
+			headerFormat: settings.headerFormat,
+			showMonthSeparators: settings.showMonthSeparators,
+			groupDaysByYear: settings.groupDaysByYear,
+			richEditor: settings.richEditor,
+			hideEmptyDays: settings.hideEmptyDays,
+			daySortDirection: settings.daySortDirection,
+		});
+	}
+
 	async onSettingsChanged(): Promise<void> {
 		this.syncFilterButton();
 		if (!this.ready) {
 			// A build is in flight against the old values - dropping the change
 			// here would leave the toolbar and the days disagreeing.
 			this.settingsPending = true;
+			return;
+		}
+		const signature = this.rebuildSettingsSignature();
+		if (signature === this.appliedSettingsSignature) {
+			const previousMax = this.appliedMaxLoadedDays;
+			this.appliedMaxLoadedDays = this.plugin.settings.maxLoadedDays;
+			if (this.appliedMaxLoadedDays < previousMax) {
+				// The cap is live: trim both physical ends as far as nearby/focused
+				// protection allows, without replacing the reader's current window.
+				this.trim("start");
+				this.trim("end");
+			}
 			return;
 		}
 		// The editor kind, date format and hidden-day handling all affect every

--- a/src/view.ts
+++ b/src/view.ts
@@ -33,6 +33,8 @@ const FLICK_STEP = 24;
 const FLICK_IDLE = 120;
 /** Quiet time (ms) after which a scroll counts as finished. */
 const SETTLE_DELAY = 180;
+/** Defensive end to a centring hold when editor focus never settles. */
+const FOCUS_CENTER_TIMEOUT = 3000;
 
 type TimelineEnd = "start" | "end";
 
@@ -79,10 +81,12 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private animFrame = 0;
 	/** Focused navigation whose editor/template layout has not settled yet. */
 	private pendingFocusCenter: DaySection | null = null;
-	/** True once the focused editor, template and cursor reveal have settled. */
-	private pendingFocusCenterReady = false;
-	/** Final correction after scroll anchoring and editor-window work go quiet. */
-	private pendingFocusCenterTimer = 0;
+	/** Time the focused editor/template/cursor layout became final. */
+	private pendingFocusCenterReadyAt = 0;
+	/** Time the current pre-paint hold began. */
+	private pendingFocusCenterStartedAt = 0;
+	/** Pre-paint correction that keeps navigation still while layout settles. */
+	private pendingFocusCenterFrame = 0;
 	/** Removes the reader-input listeners guarding `pendingFocusCenter`. */
 	private endPendingFocusCenter: (() => void) | null = null;
 	/** Delayed editor focus used only by the initial open on today. */
@@ -632,10 +636,13 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			return;
 		}
 		this.anchoring.settle();
+		// Section ResizeObserver callbacks run after layout but before paint. Keep
+		// a focused navigation centred in that same frame, so an editor replacing
+		// its shorter preview is never shown at the preview's old position.
+		this.correctPendingFocusCenter();
 		// A pane that changed size has a different set of days near enough to
 		// the viewport to be worth an editor.
 		this.editors.schedule();
-		this.schedulePendingFocusCenter();
 	}
 
 	/* ------------------------------------------------------------ scrolling */
@@ -650,7 +657,6 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.lastScrollAt = performance.now();
 		window.clearTimeout(this.settleTimer);
 		this.settleTimer = window.setTimeout(() => this.onSettle(), SETTLE_DELAY);
-		this.schedulePendingFocusCenter();
 
 		// Two steps, in this order. Within a frame, scroll events run before
 		// ResizeObserver callbacks - so when a day changed height in a
@@ -753,12 +759,16 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		// Even an editor that retained focus can have stale offscreen measurements.
 		this.armPendingFocusCenter(section);
 		section.focusEditor(atEnd);
+		// Cursor reveal registers its frame during focus. Registering this one
+		// afterwards makes the centring correction the last write before paint.
+		this.schedulePendingFocusCenter();
 	}
 
 	private armPendingFocusCenter(section: DaySection): void {
 		this.clearPendingFocusCenter();
 		this.pendingFocusCenter = section;
-		this.pendingFocusCenterReady = false;
+		this.pendingFocusCenterReadyAt = 0;
+		this.pendingFocusCenterStartedAt = performance.now();
 		const cancel = (): void => this.clearPendingFocusCenter();
 		for (const type of CENTER_CANCEL_EVENTS) this.scrollEl.addEventListener(type, cancel, CENTER_CANCEL_LISTENER);
 		this.endPendingFocusCenter = () => {
@@ -768,23 +778,53 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	private clearPendingFocusCenter(): void {
 		this.pendingFocusCenter = null;
-		this.pendingFocusCenterReady = false;
-		window.clearTimeout(this.pendingFocusCenterTimer);
-		this.pendingFocusCenterTimer = 0;
+		this.pendingFocusCenterReadyAt = 0;
+		this.pendingFocusCenterStartedAt = 0;
+		if (this.pendingFocusCenterFrame) window.cancelAnimationFrame(this.pendingFocusCenterFrame);
+		this.pendingFocusCenterFrame = 0;
 		this.endPendingFocusCenter?.();
 		this.endPendingFocusCenter = null;
 	}
 
 	private schedulePendingFocusCenter(): void {
-		if (!this.pendingFocusCenter || !this.pendingFocusCenterReady) return;
-		window.clearTimeout(this.pendingFocusCenterTimer);
-		this.pendingFocusCenterTimer = window.setTimeout(() => {
-			this.pendingFocusCenterTimer = 0;
-			const section = this.pendingFocusCenter;
+		if (!this.pendingFocusCenter || this.pendingFocusCenterFrame) return;
+		this.pendingFocusCenterFrame = window.requestAnimationFrame(() => this.holdPendingFocusCenter());
+	}
+
+	private holdPendingFocusCenter(): void {
+		this.pendingFocusCenterFrame = 0;
+		const section = this.pendingFocusCenter;
+		if (!section?.el.isConnected || !this.scrollEl?.isConnected) {
 			this.clearPendingFocusCenter();
-			if (!section?.el.isConnected || !section.hasFocus) return;
-			if (section.cardHeight <= this.scrollEl.clientHeight) this.centerOn(section, "instant");
-		}, SETTLE_DELAY);
+			return;
+		}
+		if (performance.now() - this.pendingFocusCenterStartedAt >= FOCUS_CENTER_TIMEOUT) {
+			this.clearPendingFocusCenter();
+			return;
+		}
+
+		this.correctPendingFocusCenter();
+
+		if (
+			this.pendingFocusCenterReadyAt &&
+			performance.now() - this.pendingFocusCenterReadyAt >= SETTLE_DELAY
+		) {
+			this.clearPendingFocusCenter();
+			return;
+		}
+		this.schedulePendingFocusCenter();
+	}
+
+	private correctPendingFocusCenter(): void {
+		const section = this.pendingFocusCenter;
+		if (!section?.el.isConnected || section.cardHeight > this.scrollEl.clientHeight) return;
+		const target = this.centerTarget(section);
+		if (Math.abs(target - this.scrollEl.scrollTop) < 0.5) return;
+		this.scrollEl.scrollTop = target;
+		this.editors.declareScroll();
+		this.anchoring.pin();
+		// Stay through a full quiet period after the last correction.
+		if (this.pendingFocusCenterReadyAt) this.pendingFocusCenterReadyAt = performance.now();
 	}
 
 	private centerOn(section: DaySection | undefined, behavior: "instant" | "smooth", onArrive?: () => void): void {
@@ -1089,11 +1129,10 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			return;
 		}
 		// The editor, any focus-offered template, and cursor reveal now have their
-		// layout. Centre now, then once more after anchoring and editor-window work
-		// caused by the long jump has gone quiet. A long note cannot be centred
-		// without hiding its insertion point, so its cursor reveal stays authoritative.
-		this.pendingFocusCenterReady = true;
-		this.centerOn(day, "instant");
+		// layout. Keep the pre-paint hold through one quiet period after this point.
+		// A long note cannot be centred without hiding its insertion point, so its
+		// cursor reveal stays authoritative instead.
+		this.pendingFocusCenterReadyAt = performance.now();
 		this.schedulePendingFocusCenter();
 	}
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -18,12 +18,12 @@ export const VIEW_TYPE_JOURNAL = "journal-view";
 const INITIAL_RADIUS = 7;
 /** How close to an end (px) the reader must get before more days are loaded. */
 const LOAD_THRESHOLD = 1500;
-/** Above this many live days, the end furthest from the reader is trimmed. */
-const MAX_SECTIONS = 60;
-/** How many days survive a trim. */
-const TRIM_KEEP = 48;
+/** Fraction of the loaded-day target that survives a trim (60 -> 48 by default). */
+const TRIM_KEEP_RATIO = 0.8;
 /** Days closer than this (px) to the viewport are never trimmed. */
 const TRIM_DISTANCE = LOAD_THRESHOLD * 2;
+/** Long jumps skip animation once the destination is further away than this many viewports. */
+const SMOOTH_CENTER_VIEWPORTS = 2;
 /** Per-frame scroll step (px) above which the reader is still travelling. */
 const FLICK_STEP = 24;
 /** How long after the last scroll step the view still counts as moving (ms). */
@@ -489,8 +489,10 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	 * scrolling back simply reloads it.
 	 */
 	private trim(end: TimelineEnd): void {
-		if (this.sections.length <= MAX_SECTIONS) return;
-		let budget = this.sections.length - TRIM_KEEP;
+		const maxSections = this.plugin.settings.maxLoadedDays;
+		if (this.sections.length <= maxSections) return;
+		const trimKeep = Math.floor(maxSections * TRIM_KEEP_RATIO);
+		let budget = this.sections.length - trimKeep;
 		const victims: DaySection[] = [];
 
 		if (end === "end") {
@@ -722,6 +724,11 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		);
 	}
 
+	private centerBehavior(section: DaySection): "instant" | "smooth" {
+		const distance = Math.abs(this.centerTarget(section) - this.scrollEl.scrollTop);
+		return distance > this.scrollEl.clientHeight * SMOOTH_CENTER_VIEWPORTS ? "instant" : "smooth";
+	}
+
 	private centerOn(section: DaySection | undefined, behavior: "instant" | "smooth", onArrive?: () => void): void {
 		if (!section) return;
 		if (this.animFrame) {
@@ -785,7 +792,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		}
 		// Focus only once the animation has arrived: focusing an editor makes
 		// the browser scroll it into view, which would fight the animation.
-		this.centerOn(section, "smooth", focus ? () => section.focusEditor(true) : undefined);
+		this.centerOn(section, this.centerBehavior(section), focus ? () => section.focusEditor(true) : undefined);
 	}
 
 	/** Opens the calendar, on the day the reader is currently looking at. */
@@ -848,7 +855,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		if (section) {
 			// Focusing only once the animation has arrived: focus scrolls the
 			// editor into view, which would fight it. Same as `goToToday`.
-			this.centerOn(section, "smooth", focus ? () => section.focusEditor() : undefined);
+			this.centerOn(section, this.centerBehavior(section), focus ? () => section.focusEditor() : undefined);
 			return;
 		}
 		void this.rebuild(day).then(() => {

--- a/src/view.ts
+++ b/src/view.ts
@@ -78,7 +78,11 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private scrollFrame = 0;
 	private animFrame = 0;
 	/** Focused navigation whose editor/template layout has not settled yet. */
-	private pendingFocusCenter: { section: DaySection; atEnd: boolean } | null = null;
+	private pendingFocusCenter: DaySection | null = null;
+	/** True once the focused editor, template and cursor reveal have settled. */
+	private pendingFocusCenterReady = false;
+	/** Final correction after scroll anchoring and editor-window work go quiet. */
+	private pendingFocusCenterTimer = 0;
 	/** Removes the reader-input listeners guarding `pendingFocusCenter`. */
 	private endPendingFocusCenter: (() => void) | null = null;
 	/** Delayed editor focus used only by the initial open on today. */
@@ -303,7 +307,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		) {
 			this.initialFocusTimer = window.setTimeout(() => {
 				this.initialFocusTimer = 0;
-				this.sectionAt(0)?.focusEditor(true);
+				const section = this.sectionAt(0);
+				if (section) this.focusAfterCenter(section, true);
 			}, 50);
 		}
 		// A short viewport may already sit near an end.
@@ -621,7 +626,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			this.centerOn(section, "instant");
 			if (this.focusOnFirstResize) {
 				this.focusOnFirstResize = false;
-				section.focusEditor();
+				this.focusAfterCenter(section, false);
 			}
 			this.onScroll();
 			return;
@@ -630,6 +635,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		// A pane that changed size has a different set of days near enough to
 		// the viewport to be worth an editor.
 		this.editors.schedule();
+		this.schedulePendingFocusCenter();
 	}
 
 	/* ------------------------------------------------------------ scrolling */
@@ -644,6 +650,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.lastScrollAt = performance.now();
 		window.clearTimeout(this.settleTimer);
 		this.settleTimer = window.setTimeout(() => this.onSettle(), SETTLE_DELAY);
+		this.schedulePendingFocusCenter();
 
 		// Two steps, in this order. Within a frame, scroll events run before
 		// ResizeObserver callbacks - so when a day changed height in a
@@ -743,15 +750,15 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	private focusAfterCenter(section: DaySection, atEnd: boolean): void {
-		// A day that already owns focus has completed this path before; focusing it
-		// again changes no layout and needs no delayed correction.
-		if (!section.hasFocus) this.armPendingFocusCenter(section, atEnd);
+		// Even an editor that retained focus can have stale offscreen measurements.
+		this.armPendingFocusCenter(section);
 		section.focusEditor(atEnd);
 	}
 
-	private armPendingFocusCenter(section: DaySection, atEnd: boolean): void {
+	private armPendingFocusCenter(section: DaySection): void {
 		this.clearPendingFocusCenter();
-		this.pendingFocusCenter = { section, atEnd };
+		this.pendingFocusCenter = section;
+		this.pendingFocusCenterReady = false;
 		const cancel = (): void => this.clearPendingFocusCenter();
 		for (const type of CENTER_CANCEL_EVENTS) this.scrollEl.addEventListener(type, cancel, CENTER_CANCEL_LISTENER);
 		this.endPendingFocusCenter = () => {
@@ -761,8 +768,23 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	private clearPendingFocusCenter(): void {
 		this.pendingFocusCenter = null;
+		this.pendingFocusCenterReady = false;
+		window.clearTimeout(this.pendingFocusCenterTimer);
+		this.pendingFocusCenterTimer = 0;
 		this.endPendingFocusCenter?.();
 		this.endPendingFocusCenter = null;
+	}
+
+	private schedulePendingFocusCenter(): void {
+		if (!this.pendingFocusCenter || !this.pendingFocusCenterReady) return;
+		window.clearTimeout(this.pendingFocusCenterTimer);
+		this.pendingFocusCenterTimer = window.setTimeout(() => {
+			this.pendingFocusCenterTimer = 0;
+			const section = this.pendingFocusCenter;
+			this.clearPendingFocusCenter();
+			if (!section?.el.isConnected || !section.hasFocus) return;
+			if (section.cardHeight <= this.scrollEl.clientHeight) this.centerOn(section, "instant");
+		}, SETTLE_DELAY);
 	}
 
 	private centerOn(section: DaySection | undefined, behavior: "instant" | "smooth", onArrive?: () => void): void {
@@ -813,7 +835,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.visited = null;
 		if (droppedVisited && this.plugin.settings.hideEmptyDays) {
 			void this.rebuild().then(() => {
-				if (focus) this.sectionAt(0)?.focusEditor(true);
+				const section = this.sectionAt(0);
+				if (focus && section) this.focusAfterCenter(section, true);
 			});
 			return;
 		}
@@ -822,7 +845,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			// Midnight has passed, or today was trimmed away after a long
 			// scroll - rebuilding recentres on today directly.
 			void this.rebuild().then(() => {
-				if (focus) this.sectionAt(0)?.focusEditor(true);
+				const section = this.sectionAt(0);
+				if (focus && section) this.focusAfterCenter(section, true);
 			});
 			return;
 		}
@@ -882,7 +906,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		}
 		if (changedVisited && this.plugin.settings.hideEmptyDays) {
 			void this.rebuild(day).then(() => {
-				if (focus) this.sectionAt(this.origin)?.focusEditor();
+				const section = this.sectionAt(this.origin);
+				if (focus && section) this.focusAfterCenter(section, false);
 			});
 			return;
 		}
@@ -895,13 +920,14 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			return;
 		}
 		void this.rebuild(day).then(() => {
-			if (focus) this.sectionAt(this.origin)?.focusEditor();
+			const section = this.sectionAt(this.origin);
+			if (focus && section) this.focusAfterCenter(section, false);
 		});
 	}
 
 	private focusOriginWhenReady(): void {
 		const section = this.sectionAt(this.origin);
-		if (this.centered && section) section.focusEditor();
+		if (this.centered && section) this.focusAfterCenter(section, false);
 		else this.focusOnFirstResize = true;
 	}
 
@@ -1057,14 +1083,18 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	onDayFocusSettled(day: DaySection): void {
-		const pending = this.pendingFocusCenter;
-		if (!pending || pending.section !== day) return;
-		this.clearPendingFocusCenter();
-		if (!day.el.isConnected || !day.hasFocus) return;
-		// The editor and any focus-offered template now have their real height.
-		// Repeating focus after centring preserves the cursor-at-end behavior for
-		// long notes, where the cursor matters more than the card's top edge.
-		this.centerOn(day, "instant", () => day.focusEditor(pending.atEnd));
+		if (this.pendingFocusCenter !== day) return;
+		if (!day.el.isConnected || !day.hasFocus || day.cardHeight > this.scrollEl.clientHeight) {
+			this.clearPendingFocusCenter();
+			return;
+		}
+		// The editor, any focus-offered template, and cursor reveal now have their
+		// layout. Centre now, then once more after anchoring and editor-window work
+		// caused by the long jump has gone quiet. A long note cannot be centred
+		// without hiding its insertion point, so its cursor reveal stays authoritative.
+		this.pendingFocusCenterReady = true;
+		this.centerOn(day, "instant");
+		this.schedulePendingFocusCenter();
 	}
 
 	private revalidatePaths(): void {

--- a/src/view.ts
+++ b/src/view.ts
@@ -24,6 +24,9 @@ const TRIM_KEEP_RATIO = 0.8;
 const TRIM_DISTANCE = LOAD_THRESHOLD * 2;
 /** Long jumps skip animation once the destination is further away than this many viewports. */
 const SMOOTH_CENTER_VIEWPORTS = 2;
+/** Reader input that cancels a pending post-focus navigation correction. */
+const CENTER_CANCEL_EVENTS = ["wheel", "touchmove", "pointerdown"] as const;
+const CENTER_CANCEL_LISTENER: AddEventListenerOptions = { capture: true, passive: true };
 /** Per-frame scroll step (px) above which the reader is still travelling. */
 const FLICK_STEP = 24;
 /** How long after the last scroll step the view still counts as moving (ms). */
@@ -74,6 +77,10 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private resizeObserver: ResizeObserver | null = null;
 	private scrollFrame = 0;
 	private animFrame = 0;
+	/** Focused navigation whose editor/template layout has not settled yet. */
+	private pendingFocusCenter: { section: DaySection; atEnd: boolean } | null = null;
+	/** Removes the reader-input listeners guarding `pendingFocusCenter`. */
+	private endPendingFocusCenter: (() => void) | null = null;
 	/** Delayed editor focus used only by the initial open on today. */
 	private initialFocusTimer = 0;
 	/** Focus requested while the pane still had no measurable height. */
@@ -194,6 +201,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.scrollFrame = 0;
 		if (this.animFrame) window.cancelAnimationFrame(this.animFrame);
 		this.animFrame = 0;
+		this.clearPendingFocusCenter();
 		window.clearTimeout(this.initialFocusTimer);
 		this.initialFocusTimer = 0;
 		this.focusOnFirstResize = false;
@@ -729,6 +737,34 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		return distance > this.scrollEl.clientHeight * SMOOTH_CENTER_VIEWPORTS ? "instant" : "smooth";
 	}
 
+	private centerSection(section: DaySection, focus: boolean, atEnd = false): void {
+		this.clearPendingFocusCenter();
+		this.centerOn(section, this.centerBehavior(section), focus ? () => this.focusAfterCenter(section, atEnd) : undefined);
+	}
+
+	private focusAfterCenter(section: DaySection, atEnd: boolean): void {
+		// A day that already owns focus has completed this path before; focusing it
+		// again changes no layout and needs no delayed correction.
+		if (!section.hasFocus) this.armPendingFocusCenter(section, atEnd);
+		section.focusEditor(atEnd);
+	}
+
+	private armPendingFocusCenter(section: DaySection, atEnd: boolean): void {
+		this.clearPendingFocusCenter();
+		this.pendingFocusCenter = { section, atEnd };
+		const cancel = (): void => this.clearPendingFocusCenter();
+		for (const type of CENTER_CANCEL_EVENTS) this.scrollEl.addEventListener(type, cancel, CENTER_CANCEL_LISTENER);
+		this.endPendingFocusCenter = () => {
+			for (const type of CENTER_CANCEL_EVENTS) this.scrollEl.removeEventListener(type, cancel, CENTER_CANCEL_LISTENER);
+		};
+	}
+
+	private clearPendingFocusCenter(): void {
+		this.pendingFocusCenter = null;
+		this.endPendingFocusCenter?.();
+		this.endPendingFocusCenter = null;
+	}
+
 	private centerOn(section: DaySection | undefined, behavior: "instant" | "smooth", onArrive?: () => void): void {
 		if (!section) return;
 		if (this.animFrame) {
@@ -792,7 +828,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		}
 		// Focus only once the animation has arrived: focusing an editor makes
 		// the browser scroll it into view, which would fight the animation.
-		this.centerOn(section, this.centerBehavior(section), focus ? () => section.focusEditor(true) : undefined);
+		this.centerSection(section, focus, true);
 	}
 
 	/** Opens the calendar, on the day the reader is currently looking at. */
@@ -855,7 +891,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		if (section) {
 			// Focusing only once the animation has arrived: focus scrolls the
 			// editor into view, which would fight it. Same as `goToToday`.
-			this.centerOn(section, this.centerBehavior(section), focus ? () => section.focusEditor() : undefined);
+			this.centerSection(section, focus);
 			return;
 		}
 		void this.rebuild(day).then(() => {
@@ -1018,6 +1054,17 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	onDayContentChanged(_day: DaySection): void {
 		this.find?.sectionsChanged();
+	}
+
+	onDayFocusSettled(day: DaySection): void {
+		const pending = this.pendingFocusCenter;
+		if (!pending || pending.section !== day) return;
+		this.clearPendingFocusCenter();
+		if (!day.el.isConnected || !day.hasFocus) return;
+		// The editor and any focus-offered template now have their real height.
+		// Repeating focus after centring preserves the cursor-at-end behavior for
+		// long notes, where the cursor matters more than the card's top edge.
+		this.centerOn(day, "instant", () => day.focusEditor(pending.atEnd));
 	}
 
 	private revalidatePaths(): void {


### PR DESCRIPTION
## Summary

- Snap Today and calendar jumps when the destination is more than two viewports away, while preserving smooth nearby navigation.
- Hold focused navigation at its centered position before each paint while editor/template layout, cursor reveal, and scroll anchoring settle.
- Clamp centering to reachable scroll bounds, stop immediately when an editor cannot mount, and let wheel, touch, pointer, or keyboard scrolling cancel every navigation hold.
- Add an Advanced "Days kept loaded" slider from 20 to 120, defaulting to the existing 60-day limit.
- Apply loaded-day limit changes live without rebuilding the timeline; focused and nearby days remain protected and may exceed the soft target.
- Derive the trim target from the selected limit, preserving the current 60-to-48 behavior at the default.

Fixes #16

## Verification

- npm run typecheck
- npm run build
- npm run lint
- npm run test-vault
- Added 100 consecutive older notes (2026-04-21 through 2026-07-29) to the ignored throwaway vault.
- Used Computer Use to close and freshly open Journal; all 91 post-paint samples kept Today within 0.5 px of viewport center while its preview became an editor.
- Used Computer Use to scroll the real Journal UI back to 2026-06-17 and click Today; its first displayed destination frame and all subsequent samples stayed within 0.4 px of center.
- Verified a second Today click leaves the centered position unchanged.
- Verified a real PageDown gesture cancels an intentionally prolonged centering hold and leaves the reader-selected position in place.
- Verified a synthetic unreachable center target clamps exactly to scrollHeight minus clientHeight and does not keep resetting the hold.
- Verified a simulated guarded editor-mount failure clears the centering hold immediately.
- Lowered the loaded-day target from 60 to 20 with 22 nearby sections loaded: daysEl identity, view epoch, scrollTop, and visible date were unchanged; the 22 protected nearby sections remained as documented.
- Verified a far focused calendar jump landed within 0.5 px, while a nearby jump remained smooth.
- Confirmed Obsidian captured no runtime errors.