### PR TITLE
Rest today at the top in a newest-first timeline

### DIFF
--- a/src/anchor.ts
+++ b/src/anchor.ts
@@ -1,6 +1,13 @@
 import type { DaySection } from "./day";
 import { findAnchorIndex } from "./scroll";
 
+/**
+ * Blank left above the first day once the timeline has nothing left to put
+ * there: enough to breathe, little enough that it reads as the top of the
+ * journal rather than a screen the reader has to scroll past.
+ */
+export const START_GUTTER = 24;
+
 /** The bits of the journal view the anchor needs to talk to. */
 export interface AnchorHost {
 	/** The scroller; its scroll position is what the anchor protects. */
@@ -9,6 +16,8 @@ export interface AnchorHost {
 	readonly daysEl: HTMLElement;
 	/** The live days, in order. */
 	readonly sections: DaySection[];
+	/** True when no further day can ever load above the first one. */
+	atTimelineStart(): boolean;
 	/** Declares a scroll position the anchor wrote itself. */
 	onAnchorScroll(): void;
 }
@@ -127,19 +136,42 @@ export class ScrollAnchor {
 	}
 
 	/**
-	 * Tops the padding above the first day back up to its resting height. The
-	 * spacer is what lets layout changes above the reader be absorbed without
-	 * touching the scroll position, so a run of them can spend it - and once it
-	 * is gone, corrections start writing scrollTop instead, which is what a
-	 * scroll feels as a stutter. Putting it back moves the scroll position by
-	 * exactly the height added, in the same task, so nothing on screen moves.
+	 * Returns the padding above the first day to its resting height. The spacer
+	 * is what lets layout changes above the reader be absorbed without touching
+	 * the scroll position, so a run of them can spend it - and once it is gone,
+	 * corrections start writing scrollTop instead, which is what a scroll feels
+	 * as a stutter. Putting it back moves the scroll position by exactly the
+	 * height added, in the same task, so nothing on screen moves.
 	 *
 	 * Returns true when it did the work, so the caller can treat the resulting
 	 * position as the reader's own.
 	 */
 	replenishSpacer(): boolean {
+		// Growing is the common case. Shrinking is only ever the gutter being
+		// taken back at the timeline start; a spacer that grew past its base to
+		// absorb a shift is left alone, since giving that back here could cost
+		// more scroll position than the reader has above them.
+		if (this.spacerHeight() > this.spacerBase() && !this.atStartGutter()) return false;
+		return this.restoreSpacer();
+	}
+
+	/**
+	 * Hands back the blank above the first day as soon as the reader is close
+	 * enough to reach it. Waiting for the scroll to stop would let them arrive
+	 * at the top, see the blank, and have it collected under them; a viewport
+	 * of warning is also what makes the give-back free, because the height
+	 * removed is still above the viewport and the scroll position can pay for
+	 * it in full.
+	 */
+	collapseStartSpacer(): void {
+		if (!this.atStartGutter() || this.spacerHeight() <= START_GUTTER) return;
+		this.restoreSpacer();
+	}
+
+	/** Moves the spacer to its resting height, compensated so nothing moves. */
+	private restoreSpacer(): boolean {
 		const base = this.spacerBase();
-		if (this.spacerHeight() >= base) return false;
+		if (this.spacerHeight() === base) return false;
 		const ref = this.host.sections.find((section) => section.isLaidOut)?.el;
 		if (!ref) return false;
 		const before = ref.offsetTop;
@@ -151,10 +183,27 @@ export class ScrollAnchor {
 		return true;
 	}
 
-	/** The spacer's resting height - the breathing room above the first day. */
+	/**
+	 * The spacer's resting height - the breathing room above the first day.
+	 *
+	 * Room to absorb shifts is only worth having where it cannot be seen. Once
+	 * the timeline has run out of days to put above the first one, and the
+	 * reader is within a viewport of it, the spacer is blank they could scroll
+	 * into, so it rests at a gutter instead. Both the scroll position and the
+	 * first day move together whenever the spacer changes, so that distance -
+	 * and with it this answer - does not change underneath the change itself.
+	 */
 	spacerBase(): number {
 		const height = this.host.scrollEl?.clientHeight ?? 0;
-		return height > 0 ? Math.round(height * 0.4) : this.spacerHeight();
+		if (height <= 0) return this.spacerHeight();
+		return this.atStartGutter() ? START_GUTTER : Math.round(height * 0.4);
+	}
+
+	private atStartGutter(): boolean {
+		if (!this.host.atTimelineStart()) return false;
+		const first = this.host.sections.find((section) => section.isLaidOut);
+		if (!first) return false;
+		return this.host.scrollEl.scrollTop - first.dayTop < this.host.scrollEl.clientHeight;
 	}
 
 	spacerHeight(): number {

--- a/src/day.ts
+++ b/src/day.ts
@@ -282,6 +282,11 @@ export class DaySection {
 		return this.headerEl.getBoundingClientRect().top;
 	}
 
+	/** Top of the whole day, headings included - where the day starts on screen. */
+	get dayTop(): number {
+		return this.el.offsetTop;
+	}
+
 	/** Card geometry excludes the optional year and month headings above the day. */
 	get cardTop(): number {
 		return this.el.offsetTop + this.cardEl.offsetTop;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -67,7 +67,7 @@ interface InternalCodeMirror {
  * window, where Obsidian floats its status bar over it, so a cursor scrolled to
  * the very edge is both cramped and liable to sit under that.
  */
-const REVEAL_LINES = 2;
+const REVEAL_LINES = 4;
 /** Used only when the editor cannot say how tall its lines are. */
 const FALLBACK_LINE_HEIGHT = 24;
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,6 +1,6 @@
 import { ItemView, Scope, TAbstractFile, TFile, WorkspaceLeaf } from "obsidian";
 import type JournalViewPlugin from "./main";
-import { AnchorHost, ScrollAnchor } from "./anchor";
+import { AnchorHost, START_GUTTER, ScrollAnchor } from "./anchor";
 import { DatePickerModal } from "./datePicker";
 import { DayHost, DaySection } from "./day";
 import { DayWalker, isOffsetReachable } from "./dayWalk";
@@ -258,7 +258,6 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.lastScrollAt = 0;
 		this.scrollStep = 0;
 		this.anchoring.resetSpacer();
-		if (this.scrollEl.clientHeight > 0) this.anchoring.setSpacer(this.anchoring.spacerBase());
 		this.attachResizeObserver();
 
 		// The chosen day, plus a few days either side.
@@ -300,6 +299,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 		this.ready = true;
 		if (this.scrollEl.clientHeight > 0) {
+			// Only now is it known whether days can still arrive above the first
+			// one, which is what decides the spacer's resting height.
+			this.anchoring.setSpacer(this.anchoring.spacerBase());
 			this.centerOn(this.sectionAt(origin), "instant");
 			this.centered = true;
 			// The days on screen become editors before the reader has looked at
@@ -590,6 +592,11 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.anchoring.settle();
 	}
 
+	/** True once the walk has run out of days to put above the first one. */
+	atTimelineStart(): boolean {
+		return this.exhausted.start;
+	}
+
 	onAnchorScroll(): void {
 		this.editors.declareScroll();
 	}
@@ -674,6 +681,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		// by exactly the amount the day grew.
 		this.anchoring.settle();
 		this.anchoring.pin();
+		// Approaching the top of the timeline: give back the spacer before the
+		// reader is close enough to see it as blank.
+		this.anchoring.collapseStartSpacer();
 
 		if (this.scrollFrame) return;
 		this.scrollFrame = window.requestAnimationFrame(() => {
@@ -746,11 +756,11 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	/**
 	 * Today sits at the top of a newest-first timeline: everything a centred day
-	 * would be pushed down by is either empty future dates or the padding that
-	 * holds room for them. Resting it against the top of the viewport instead
-	 * shows as much of the day as the pane can hold, which is what the reader
-	 * came back for. Older days, and today in an oldest-first timeline, still
-	 * centre - they have real days on both sides.
+	 * would be pushed down by is either empty future dates or the room held for
+	 * them. Resting it just below the top of the viewport instead shows as much
+	 * of the day as the pane can hold, which is what the reader came back for.
+	 * Older days, and today in an oldest-first timeline, still centre - they
+	 * have real days on both sides.
 	 */
 	private restsAtTop(section: DaySection): boolean {
 		return this.sortStep() === -1 && section.offset === 0;
@@ -758,11 +768,13 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	/** Where the scroller has to sit for `section` to be in its resting place. */
 	private restTarget(section: DaySection): number {
-		const lead = this.restsAtTop(section)
-			? 0
-			: Math.max(0, (this.scrollEl.clientHeight - section.cardHeight) / 2);
-		const target = Math.max(0, section.cardTop - lead);
-		return Math.min(target, Math.max(0, this.scrollEl.scrollHeight - this.scrollEl.clientHeight));
+		// A day resting at the top is measured whole, headings included: they
+		// name the month the reader is arriving in, so they belong on screen.
+		const target = this.restsAtTop(section)
+			? section.dayTop - START_GUTTER
+			: section.cardTop - Math.max(0, (this.scrollEl.clientHeight - section.cardHeight) / 2);
+		const limit = Math.max(0, this.scrollEl.scrollHeight - this.scrollEl.clientHeight);
+		return Math.min(Math.max(0, target), limit);
 	}
 
 	private centerBehavior(section: DaySection): "instant" | "smooth" {

--- a/src/view.ts
+++ b/src/view.ts
@@ -744,16 +744,29 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		await this.rebuild(date, false);
 	}
 
-	private centerTarget(section: DaySection): number {
-		const target = Math.max(
-			0,
-			section.cardTop - Math.max(0, (this.scrollEl.clientHeight - section.cardHeight) / 2),
-		);
+	/**
+	 * Today sits at the top of a newest-first timeline: everything a centred day
+	 * would be pushed down by is either empty future dates or the padding that
+	 * holds room for them. Resting it against the top of the viewport instead
+	 * shows as much of the day as the pane can hold, which is what the reader
+	 * came back for. Older days, and today in an oldest-first timeline, still
+	 * centre - they have real days on both sides.
+	 */
+	private restsAtTop(section: DaySection): boolean {
+		return this.sortStep() === -1 && section.offset === 0;
+	}
+
+	/** Where the scroller has to sit for `section` to be in its resting place. */
+	private restTarget(section: DaySection): number {
+		const lead = this.restsAtTop(section)
+			? 0
+			: Math.max(0, (this.scrollEl.clientHeight - section.cardHeight) / 2);
+		const target = Math.max(0, section.cardTop - lead);
 		return Math.min(target, Math.max(0, this.scrollEl.scrollHeight - this.scrollEl.clientHeight));
 	}
 
 	private centerBehavior(section: DaySection): "instant" | "smooth" {
-		const distance = Math.abs(this.centerTarget(section) - this.scrollEl.scrollTop);
+		const distance = Math.abs(this.restTarget(section) - this.scrollEl.scrollTop);
 		return distance > this.scrollEl.clientHeight * SMOOTH_CENTER_VIEWPORTS ? "instant" : "smooth";
 	}
 
@@ -826,7 +839,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private correctPendingFocusCenter(): void {
 		const section = this.pendingFocusCenter;
 		if (!section?.el.isConnected || section.cardHeight > this.scrollEl.clientHeight) return;
-		const target = this.centerTarget(section);
+		const target = this.restTarget(section);
 		if (Math.abs(target - this.scrollEl.scrollTop) < 0.5) return;
 		const before = this.scrollEl.scrollTop;
 		this.scrollEl.scrollTop = target;
@@ -844,7 +857,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			this.animFrame = 0;
 		}
 		if (behavior === "instant") {
-			this.scrollEl.scrollTop = this.centerTarget(section);
+			this.scrollEl.scrollTop = this.restTarget(section);
 			this.editors.declareScroll();
 			this.anchoring.pin();
 			onArrive?.();
@@ -860,7 +873,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		const step = () => {
 			this.animFrame = 0;
 			if (!this.scrollEl || !section.el.isConnected) return;
-			const target = this.centerTarget(section);
+			const target = this.restTarget(section);
 			const remaining = target - this.scrollEl.scrollTop;
 			if (Math.abs(remaining) < 4 || performance.now() - started > 1500) {
 				this.scrollEl.scrollTop = target;

--- a/styles.css
+++ b/styles.css
@@ -180,7 +180,9 @@ button.journal-find-button.is-active {
 	flex-direction: column;
 	/* Leaves room so the first and last day can still be centred. The view
 	   updates the custom property to absorb layout shifts above the reader
-	   without touching scrollTop. */
+	   without touching scrollTop, and drops it to a gutter once the timeline
+	   has no more days to put above the first one - room the reader cannot
+	   reach is worth having, blank they can scroll into is not. */
 	padding: var(--journal-padding-top, 40vh) var(--size-4-4) 40vh;
 	margin: 0 auto;
 	max-width: var(--file-line-width, 700px);


### PR DESCRIPTION
Fixes #3.

## User-visible effect

With **Day order: Newest to oldest**, opening the journal or pressing "Go to today" left a screen of whitespace above today's note, and scrolling back to the top found it again.

The padding above the first day is not decoration: it is what lets days growing above the reader be absorbed without writing `scrollTop`, which is what a scroll feels as a stutter. Measured on a scroll back up through history, it absorbed roughly half of 1368px of drift. So it stays — but only where it cannot be seen.

Once the timeline has no more days to put above the first one, that padding is blank the reader can scroll into, so it now rests at a 24px gutter instead. The give-back happens while the reader is still a viewport away from the top, where the height removed is above the viewport and the scroll position can pay for it in full — nothing on screen moves. Off the top it returns to its full height and goes on absorbing.

Today in a newest-first journal now rests just below the top of the pane rather than centred, with its date headings on screen. Older days, and today in an oldest-first journal, still centre.

## Verification

By hand in `test-vault` (rebuilt and reloaded, focus emulation on), measuring against the top of the scroller:

- Newest to oldest, empty days hidden — opening the journal: `scrollTop` 0, spacer 24px, today 24px below the top, nothing to scroll up into. Same for "Go to today" from 8400px deep, and for a view built while its pane was hidden and then revealed.
- Scrolling the whole way back up from deep in history: the first day's top never fell below the top of the viewport at any frame, so no blank was ever visible; the spacer was 663px while deep and 24px at rest.
- A single-frame jump from deep to `scrollTop` 0 (a fast scrollbar drag): lands with the 24px gutter, no blank left behind.
- Spacer absorption still working away from the top: 11 upward drifts totalling 496px, all 496 absorbed rather than written to `scrollTop`.
- Newest to oldest, empty days shown — 13 future days above today; "Go to today" scrolls past them and rests today 24px below the top, spacer left at its full 265px.
- "Go to date" on an older day: still centred (243px lead, centre 243px). Oldest to newest, "Go to today": still centred (121px, centre 122px).
- `dev:errors` clean throughout; `npm run typecheck` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)