### PR TITLE
Keep workspace.activeEditor correct when clicking on non-editor leaf

### DIFF
--- a/src/day.ts
+++ b/src/day.ts
@@ -1,4 +1,5 @@
 import { App, Component, MarkdownRenderer, Notice, TFile, getFrontMatterInfo, setIcon, setTooltip } from "obsidian";
+import type { WorkspaceLeaf } from "obsidian";
 import type JournalViewPlugin from "./main";
 import { JournalEditor, createJournalEditor } from "./editor";
 import type { Moment } from "./moment";
@@ -16,6 +17,7 @@ const REVEAL_FRAMES = 10;
 /** The bits of the journal view a day needs to talk to. */
 export interface DayHost {
 	app: App;
+	leaf: WorkspaceLeaf;
 	plugin: JournalViewPlugin;
 	/** Called when a day's underlying file appears, disappears or is renamed. */
 	onDayFileChanged(day: DaySection, previousPath: string | null): void;
@@ -623,6 +625,8 @@ export class DaySection {
 			this.editor = createJournalEditor(
 				{
 					app: this.host.app,
+					leaf: this.host.leaf,
+					workspaceEditors: this.host.plugin.workspaceEditors,
 					container: this.bodyEl,
 					value: body,
 					placeholder,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -7,6 +7,8 @@ import type { FindRange } from "./findText";
 
 export interface JournalEditorOptions {
 	app: App;
+	leaf: WorkspaceLeaf;
+	workspaceEditors: WorkspaceEditorBridge;
 	container: HTMLElement;
 	value: string;
 	placeholder: string;
@@ -103,9 +105,8 @@ interface InternalEditorInstance {
 	unload?(): void;
 }
 
-interface InternalEditorOwner {
+interface InternalEditorOwner extends ActiveEditorOwner {
 	app: App;
-	file: TFile | null;
 	hoverPopover: null;
 	getMode(): string;
 	getFile(): TFile | null;
@@ -120,40 +121,99 @@ interface InternalEditorOwner {
 
 interface ActiveEditorOwner {
 	file: TFile | null;
+	leaf: WorkspaceLeaf;
 }
 
 interface WorkspaceEditorHost {
 	activeEditor: unknown;
 	lastActiveFile?: TFile | null;
+	recentFileTracker?: {
+		onFileOpen(file: TFile | null, previous: TFile | null): void;
+	};
 	getActiveFile(): TFile | null;
 	trigger(name: string, ...data: unknown[]): void;
 }
 
 type WorkspaceEditorUpdate = "claim" | "release" | "file";
 
-let currentlyActiveDayEditor: ActiveEditorOwner | null = null;
+/**
+ * Bridges journal editors into Obsidian's workspace bookkeeping. The state is
+ * owned by one plugin/app instance, while the per-leaf map prevents one journal
+ * tab from lending its hidden editor to another.
+ */
+export class WorkspaceEditorBridge {
+	private readonly journalLeaves = new WeakSet<WorkspaceLeaf>();
+	private readonly activeByLeaf = new WeakMap<WorkspaceLeaf, ActiveEditorOwner>();
+	private lastActive: ActiveEditorOwner | null = null;
 
-// Keeps the day being edited as the activeEditor when the user clicks on a non-editor
-// leaf, for example a widget tab on a sidebar.
-// This fixes an issue where the file pane's "auto reveal current file" would break
-// when you click on a sidebar.
-export function onActiveLeafChange(app: App, leaf: WorkspaceLeaf | null): void {
-	// If we aren't using the journal view, do nothing.
-	if (!currentlyActiveDayEditor) return;
-	try {
-		// If the user is switching to a file, do nothing.
-		if (leaf?.view instanceof FileView) {
-			currentlyActiveDayEditor = null;
-			return;
+	constructor(private readonly app: App) {}
+
+	registerJournalLeaf(leaf: WorkspaceLeaf): () => void {
+		this.journalLeaves.add(leaf);
+		return () => {
+			this.journalLeaves.delete(leaf);
+			const owner = this.activeByLeaf.get(leaf);
+			this.activeByLeaf.delete(leaf);
+			if (this.lastActive === owner) this.lastActive = null;
+		};
+	}
+
+	/**
+	 * Restores the last day while a non-file pane is active. Journal tabs restore
+	 * their own day; real files keep Obsidian's native editor; deferred leaves are
+	 * left alone until their eventual view type is knowable.
+	 */
+	onActiveLeafChange(leaf: WorkspaceLeaf | null): void {
+		try {
+			if (leaf?.isDeferred) return;
+			if (leaf?.view instanceof FileView) {
+				this.lastActive = null;
+				return;
+			}
+
+			let owner = this.lastActive;
+			if (leaf && this.journalLeaves.has(leaf)) {
+				owner = this.activeByLeaf.get(leaf) ?? null;
+				this.lastActive = owner;
+			}
+			if (!owner) return;
+
+			const workspace = this.app.workspace as unknown as WorkspaceEditorHost;
+			if (!workspace.activeEditor) workspace.activeEditor = owner;
+		} catch (error) {
+			console.warn("Journal View: failed to keep workspace.activeEditor", error);
 		}
-		// If the user clicked into a non-file pane (i.e. the sidebar), and nothing else
-		// has claimed activeEditor, reassign activeEditor back to the day the user was
-		// just editing.
-		const workspace = app.workspace as unknown as WorkspaceEditorHost;
-		if (!workspace.activeEditor) workspace.activeEditor = currentlyActiveDayEditor;
-	} catch (error) {
-		// just in case the activeEditor API ever changes
-		console.warn("Journal View: failed to keep workspace.activeEditor", error);
+	}
+
+	update(owner: ActiveEditorOwner, update: WorkspaceEditorUpdate, notifyRelease = false): void {
+		try {
+			const workspace = this.app.workspace as unknown as WorkspaceEditorHost;
+			if (update === "claim") {
+				// The embedded editor itself may have assigned this owner before its
+				// focus event bubbles to us; it does not emit the file notification.
+				workspace.activeEditor = owner;
+				this.activeByLeaf.set(owner.leaf, owner);
+				this.lastActive = owner;
+				notifyFileOpen(workspace, owner.file);
+			} else if (update === "release") {
+				if (notifyRelease) {
+					if (this.activeByLeaf.get(owner.leaf) === owner) this.activeByLeaf.delete(owner.leaf);
+					if (this.lastActive === owner) this.lastActive = null;
+				}
+				const owned = workspace.activeEditor === owner;
+				if (owned) workspace.activeEditor = null;
+				else if (workspace.activeEditor !== null) return;
+				// A view owns many mounted editors. Only the one the workspace still
+				// considers current should clear file followers during bulk teardown.
+				if (notifyRelease && (owned || workspace.getActiveFile() === owner.file)) {
+					notifyFileOpen(workspace, null);
+				}
+			} else if (update === "file" && workspace.activeEditor === owner) {
+				notifyFileOpen(workspace, owner.file);
+			}
+		} catch (error) {
+			console.warn("Journal View: could not update the workspace editor", error);
+		}
 	}
 }
 
@@ -168,44 +228,20 @@ function focusStayedInside(container: HTMLElement, event: FocusEvent): boolean {
  * assigning `activeEditor` is enough for editor commands and `getActiveFile`,
  * but does not tell Outline, Backlinks, or Properties to follow it.
  */
-function updateWorkspaceEditor(
-	app: App,
-	owner: ActiveEditorOwner,
-	update: WorkspaceEditorUpdate,
-	notifyRelease = false,
-): void {
-	try {
-		const workspace = app.workspace as unknown as WorkspaceEditorHost;
-		if (update === "claim") {
-			// The embedded editor itself may have assigned this owner before its
-			// focus event bubbles to us; it does not emit the file notification.
-			workspace.activeEditor = owner;
-			currentlyActiveDayEditor = owner;
-			notifyFileOpen(workspace, owner.file);
-		} else if (update === "release") {
-			if (notifyRelease && currentlyActiveDayEditor === owner) currentlyActiveDayEditor = null;
-			const owned = workspace.activeEditor === owner;
-			if (owned) workspace.activeEditor = null;
-			else if (workspace.activeEditor !== null) return;
-			// A view owns many mounted editors. Only the one the workspace still
-			// considers current should clear file followers during bulk teardown.
-			if (notifyRelease && (owned || workspace.getActiveFile() === owner.file)) {
-				notifyFileOpen(workspace, null);
-			}
-		} else if (update === "file" && workspace.activeEditor === owner) {
-			notifyFileOpen(workspace, owner.file);
-		}
-	} catch (error) {
-		console.warn("Journal View: could not update the workspace editor", error);
-	}
-}
-
-/**
- * Announces a file the way Obsidian does, keeping its record of what it last
- * announced.
- */
 function notifyFileOpen(workspace: WorkspaceEditorHost, file: TFile | null): void {
-	if ("lastActiveFile" in workspace) workspace.lastActiveFile = file;
+	if ("lastActiveFile" in workspace) {
+		const previous = workspace.lastActiveFile ?? null;
+		if (previous !== file) {
+			try {
+				// Obsidian normally records the file being left immediately before it
+				// updates lastActiveFile. A manual notification must preserve that step.
+				workspace.recentFileTracker?.onFileOpen(file, previous);
+			} catch (error) {
+				console.warn("Journal View: could not preserve recent-file tracking", error);
+			}
+		}
+		workspace.lastActiveFile = file;
+	}
 	workspace.trigger("file-open", file);
 }
 
@@ -283,6 +319,7 @@ class RichEditor implements JournalEditor {
 		this.owner = {
 			app: options.app,
 			file: options.file,
+			leaf: options.leaf,
 			hoverPopover: null,
 			getMode: () => "source",
 			getFile: () => this.options.file,
@@ -332,14 +369,14 @@ class RichEditor implements JournalEditor {
 
 		this.focusIn = (event) => {
 			if (focusStayedInside(options.container, event)) return;
-			updateWorkspaceEditor(this.options.app, this.owner, "claim");
+			this.options.workspaceEditors.update(this.owner, "claim");
 			this.scheduleWorkspaceContent();
 			this.options.onFocus();
 		};
 		this.focusOut = (event) => {
 			if (focusStayedInside(options.container, event)) return;
 			this.cancelWorkspaceContent();
-			updateWorkspaceEditor(this.options.app, this.owner, "release");
+			this.options.workspaceEditors.update(this.owner, "release");
 			this.options.onBlur();
 		};
 		options.container.addEventListener("focusin", this.focusIn);
@@ -441,7 +478,7 @@ class RichEditor implements JournalEditor {
 	setFile(file: TFile | null): void {
 		this.options.file = file;
 		this.owner.file = file;
-		updateWorkspaceEditor(this.options.app, this.owner, "file");
+		this.options.workspaceEditors.update(this.owner, "file");
 		this.scheduleWorkspaceContent();
 	}
 
@@ -574,7 +611,7 @@ class RichEditor implements JournalEditor {
 		// A blur deliberately leaves file-following panes on the last edited day.
 		// Teardown runs after the internal editor has finished its own focus work,
 		// then clears the owner unless another editor claimed the workspace.
-		updateWorkspaceEditor(this.options.app, this.owner, "release", true);
+		this.options.workspaceEditors.update(this.owner, "release", true);
 		this.instance = null;
 		this.options.container.empty();
 	}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from "obsidian";
+import { App, FileView, TFile, WorkspaceLeaf } from "obsidian";
 import { StateEffect, StateField } from "@codemirror/state";
 import type { EditorState, TransactionSpec } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
@@ -124,11 +124,38 @@ interface ActiveEditorOwner {
 
 interface WorkspaceEditorHost {
 	activeEditor: unknown;
+	lastActiveFile?: TFile | null;
 	getActiveFile(): TFile | null;
 	trigger(name: string, ...data: unknown[]): void;
 }
 
 type WorkspaceEditorUpdate = "claim" | "release" | "file";
+
+let currentlyActiveDayEditor: ActiveEditorOwner | null = null;
+
+// Keeps the day being edited as the activeEditor when the user clicks on a non-editor
+// leaf, for example a widget tab on a sidebar.
+// This fixes an issue where the file pane's "auto reveal current file" would break
+// when you click on a sidebar.
+export function onActiveLeafChange(app: App, leaf: WorkspaceLeaf | null): void {
+	// If we aren't using the journal view, do nothing.
+	if (!currentlyActiveDayEditor) return;
+	try {
+		// If the user is switching to a file, do nothing.
+		if (leaf?.view instanceof FileView) {
+			currentlyActiveDayEditor = null;
+			return;
+		}
+		// If the user clicked into a non-file pane (i.e. the sidebar), and nothing else
+		// has claimed activeEditor, reassign activeEditor back to the day the user was
+		// just editing.
+		const workspace = app.workspace as unknown as WorkspaceEditorHost;
+		if (!workspace.activeEditor) workspace.activeEditor = currentlyActiveDayEditor;
+	} catch (error) {
+		// just in case the activeEditor API ever changes
+		console.warn("Journal View: failed to keep workspace.activeEditor", error);
+	}
+}
 
 function focusStayedInside(container: HTMLElement, event: FocusEvent): boolean {
 	const NodeCtor = container.ownerDocument.defaultView?.Node;
@@ -153,22 +180,33 @@ function updateWorkspaceEditor(
 			// The embedded editor itself may have assigned this owner before its
 			// focus event bubbles to us; it does not emit the file notification.
 			workspace.activeEditor = owner;
-			workspace.trigger("file-open", owner.file);
+			currentlyActiveDayEditor = owner;
+			notifyFileOpen(workspace, owner.file);
 		} else if (update === "release") {
+			if (notifyRelease && currentlyActiveDayEditor === owner) currentlyActiveDayEditor = null;
 			const owned = workspace.activeEditor === owner;
 			if (owned) workspace.activeEditor = null;
 			else if (workspace.activeEditor !== null) return;
 			// A view owns many mounted editors. Only the one the workspace still
 			// considers current should clear file followers during bulk teardown.
 			if (notifyRelease && (owned || workspace.getActiveFile() === owner.file)) {
-				workspace.trigger("file-open", null);
+				notifyFileOpen(workspace, null);
 			}
 		} else if (update === "file" && workspace.activeEditor === owner) {
-			workspace.trigger("file-open", owner.file);
+			notifyFileOpen(workspace, owner.file);
 		}
 	} catch (error) {
 		console.warn("Journal View: could not update the workspace editor", error);
 	}
+}
+
+/**
+ * Announces a file the way Obsidian does, keeping its record of what it last
+ * announced.
+ */
+function notifyFileOpen(workspace: WorkspaceEditorHost, file: TFile | null): void {
+	if ("lastActiveFile" in workspace) workspace.lastActiveFile = file;
+	workspace.trigger("file-open", file);
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { MarkdownView, Plugin, TFile, WorkspaceLeaf, debounce } from "obsidian";
 import { DailyNoteResolver } from "./dailyNotes";
-import { onActiveLeafChange } from "./editor";
+import { WorkspaceEditorBridge } from "./editor";
 import { createMoment } from "./moment";
 import type { Moment } from "./moment";
 import { DAY_KEY_FORMAT, DailyNoteIndex } from "./noteIndex";
@@ -20,6 +20,7 @@ export default class JournalViewPlugin extends Plugin {
 	settings: JournalViewSettings = { ...DEFAULT_SETTINGS };
 	daily!: DailyNoteResolver;
 	index!: DailyNoteIndex;
+	readonly workspaceEditors = new WorkspaceEditorBridge(this.app);
 	private dailyNoteActions = new Map<MarkdownView, HTMLElement>();
 	/** Target dates handed to journal views before Obsidian constructs them. */
 	private initialDates = new Map<WorkspaceLeaf, Moment>();
@@ -65,7 +66,9 @@ export default class JournalViewPlugin extends Plugin {
 		);
 		this.registerEvent(this.app.workspace.on("file-open", () => this.syncDailyNoteActions()));
 		this.registerEvent(this.app.workspace.on("layout-change", () => this.syncDailyNoteActions()));
-		this.registerEvent(this.app.workspace.on("active-leaf-change", (leaf) => onActiveLeafChange(this.app, leaf)));
+		this.registerEvent(
+			this.app.workspace.on("active-leaf-change", (leaf) => this.workspaceEditors.onActiveLeafChange(leaf)),
+		);
 		this.register(() => this.clearDailyNoteActions());
 
 		this.registerView(VIEW_TYPE_JOURNAL, (leaf) => new JournalView(leaf, this));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { MarkdownView, Plugin, TFile, WorkspaceLeaf, debounce } from "obsidian";
 import { DailyNoteResolver } from "./dailyNotes";
+import { onActiveLeafChange } from "./editor";
 import { createMoment } from "./moment";
 import type { Moment } from "./moment";
 import { DAY_KEY_FORMAT, DailyNoteIndex } from "./noteIndex";
@@ -64,6 +65,7 @@ export default class JournalViewPlugin extends Plugin {
 		);
 		this.registerEvent(this.app.workspace.on("file-open", () => this.syncDailyNoteActions()));
 		this.registerEvent(this.app.workspace.on("layout-change", () => this.syncDailyNoteActions()));
+		this.registerEvent(this.app.workspace.on("active-leaf-change", (leaf) => onActiveLeafChange(this.app, leaf)));
 		this.register(() => this.clearDailyNoteActions());
 
 		this.registerView(VIEW_TYPE_JOURNAL, (leaf) => new JournalView(leaf, this));

--- a/src/view.ts
+++ b/src/view.ts
@@ -122,6 +122,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		readonly plugin: JournalViewPlugin,
 	) {
 		super(leaf);
+		this.register(plugin.workspaceEditors.registerJournalLeaf(leaf));
 		// Obsidian's workspace scope handles Escape before the find bar's DOM
 		// listener can. Claim it only while focus is in journal-wide find, leaving
 		// embedded-editor Escape handling (including Vim mode) untouched.


### PR DESCRIPTION
This PR fixes a couple of minor issues with the file manager pane not showing the correct file as currently active.

It may have other effects that I'm not aware of, but any such effects should be to fix other incorrect behavior.

### Before

(note that every time the mouse goes over the sidebar, I am clicking on it, sorry this is hard to see)

[Screencast_20260830_064305.webm](https://github.com/user-attachments/assets/b40761a8-9cda-4e1b-bd6b-381b34c9cafb)

### After

[Screencast_20260830_064404.webm](https://github.com/user-attachments/assets/614c77f8-d166-4fff-b5e9-f39f59ecdafa)
