### PR TITLE
Add journal metadata customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Open Journal View from the sidebar or run **Open journal** from the command pale
   return to today in one click, or open the surrounding days from the notebook button on a daily note.
 - **Edit directly in the timeline.** Read and write without switching between files, views, or editing
   modes.
-- **Keep useful context in sight.** The Customization button can show frontmatter tags and selected
-  properties, such as `mood`, above every daily-note body.
+- **Keep useful context in sight.** The Customization button can show editable frontmatter tags and
+  selected properties, such as `mood`, above every daily-note body.
 - **Write only when there is something to say.** Start typing on an empty day and Journal View creates
   the daily note only when you need it.
 - **Rediscover past entries.** Search across your journal to quickly find notes, ideas, and memories
@@ -32,6 +32,8 @@ vault handles daily notes.
 
 The settings button beside the journal filter opens **Customization**. Its tag toggle and
 property list are shared by every open Journal View and saved across restarts.
+Click a displayed value to edit it, clear it to remove that property from the note, or use the tag
+chips to add and remove frontmatter tags. Tag controls stay available on existing tagless notes.
 
 | Setting | Default | What it does |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Open Journal View from the sidebar or run **Open journal** from the command pale
   return to today in one click, or open the surrounding days from the notebook button on a daily note.
 - **Edit directly in the timeline.** Read and write without switching between files, views, or editing
   modes.
-- **Keep useful context in sight.** The Customization button can show editable frontmatter tags and
-  selected properties, such as `mood`, above every daily-note body.
 - **Write only when there is something to say.** Start typing on an empty day and Journal View creates
   the daily note only when you need it.
 - **Rediscover past entries.** Search across your journal to quickly find notes, ideas, and memories
@@ -30,10 +28,7 @@ Journal View uses your existing daily-note configuration by default. You can ove
 format, folder, and template in **Settings → Journal View** without changing how the rest of your
 vault handles daily notes.
 
-The settings button beside the journal filter opens **Customization**. Its tag toggle and
-property list are shared by every open Journal View and saved across restarts.
-Click a displayed value to edit it, clear it to remove that property from the note, or use the tag
-chips to add and remove frontmatter tags. Tag controls stay available on existing tagless notes.
+Some Customization is only visible in the customization menu accessible from the view's toolbar.
 
 | Setting | Default | What it does |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Open Journal View from the sidebar or run **Open journal** from the command pale
   return to today in one click, or open the surrounding days from the notebook button on a daily note.
 - **Edit directly in the timeline.** Read and write without switching between files, views, or editing
   modes.
+- **Keep useful context in sight.** The Customization button can show frontmatter tags and selected
+  properties, such as `mood`, above every daily-note body.
 - **Write only when there is something to say.** Start typing on an empty day and Journal View creates
   the daily note only when you need it.
 - **Rediscover past entries.** Search across your journal to quickly find notes, ideas, and memories
@@ -27,6 +29,9 @@ Open Journal View from the sidebar or run **Open journal** from the command pale
 Journal View uses your existing daily-note configuration by default. You can override the date
 format, folder, and template in **Settings → Journal View** without changing how the rest of your
 vault handles daily notes.
+
+The settings button beside the journal filter opens **Customization**. Its tag toggle and
+property list are shared by every open Journal View and saved across restarts.
 
 | Setting | Default | What it does |
 | --- | --- | --- |

--- a/src/appearance.ts
+++ b/src/appearance.ts
@@ -1,0 +1,205 @@
+import { AbstractInputSuggest, App, Modal, Notice, Setting } from "obsidian";
+import type JournalViewPlugin from "./main";
+
+interface AppearanceModalOptions {
+	onDismiss?(): void;
+}
+
+/** Autocomplete attached to the property-name field. */
+class PropertySuggest extends AbstractInputSuggest<string> {
+	constructor(
+		app: App,
+		input: HTMLInputElement,
+		private readonly items: () => string[],
+		private readonly onValueSelected: (value: string) => void,
+	) {
+		super(app, input);
+	}
+
+	protected getSuggestions(query: string): string[] {
+		const needle = query.trim().toLocaleLowerCase();
+		return this.items().filter((item) => !needle || item.toLocaleLowerCase().includes(needle));
+	}
+
+	renderSuggestion(value: string, el: HTMLElement): void {
+		el.setText(value);
+	}
+
+	selectSuggestion(value: string): void {
+		this.setValue(value);
+		this.close();
+		this.onValueSelected(value);
+	}
+}
+
+/** Global, immediately persisted controls for the metadata shown on each day. */
+export class AppearanceModal extends Modal {
+	private propertyInput!: HTMLInputElement;
+	private addButton!: HTMLButtonElement;
+	private propertyList!: HTMLElement;
+	private suggest: PropertySuggest | null = null;
+	private knownProperties: string[] = [];
+	private saving: Promise<void> = Promise.resolve();
+
+	constructor(
+		app: App,
+		private plugin: JournalViewPlugin,
+		private options: AppearanceModalOptions = {},
+	) {
+		super(app);
+	}
+
+	onOpen(): void {
+		this.modalEl.addClass("journal-appearance-modal");
+		this.titleEl.setText("Customization");
+		this.knownProperties = this.discoverProperties();
+
+		new Setting(this.contentEl)
+			.setName("Display tags")
+			.setDesc("Show tags from each daily note's frontmatter above its body.")
+			.addToggle((toggle) =>
+				toggle.setValue(this.plugin.settings.showTags).onChange((value) => {
+					this.plugin.settings.showTags = value;
+					this.persist();
+				}),
+			);
+
+		new Setting(this.contentEl)
+			.setName("Properties")
+			.setDesc("Choose frontmatter properties to show on every existing daily note.");
+
+		const add = new Setting(this.contentEl).setName("Add property");
+		add.settingEl.addClass("journal-appearance-add-property");
+		add.addText((text) => {
+			text.setPlaceholder("Property name").onChange((value) => this.syncAddButton(value));
+			this.propertyInput = text.inputEl;
+			this.propertyInput.addEventListener("keydown", (event) => {
+				if (event.key !== "Enter" || event.isComposing) return;
+				event.preventDefault();
+				this.addProperty(this.propertyInput.value);
+			});
+		});
+		add.addButton((button) => {
+			button.setButtonText("Add").setCta().setDisabled(true);
+			this.addButton = button.buttonEl;
+			this.addButton.type = "button";
+			// Commit before clicking the button blurs the autocomplete input. Its
+			// popover can otherwise consume the gesture while it closes.
+			this.addButton.addEventListener("pointerdown", (event) => {
+				if (event.button !== 0 || this.addButton.disabled) return;
+				event.preventDefault();
+				this.addProperty(this.propertyInput.value);
+			});
+			// Keyboard and assistive clicks do not have a pointer event.
+			this.addButton.addEventListener("click", (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				if (event.detail === 0) this.addProperty(this.propertyInput.value);
+			});
+		});
+		this.suggest = new PropertySuggest(
+			this.app,
+			this.propertyInput,
+			() => this.availableProperties(),
+			(value) => {
+				this.syncAddButton(value);
+				this.propertyInput.focus();
+			},
+		);
+
+		this.propertyList = this.contentEl.createDiv({ cls: "journal-appearance-properties" });
+		this.renderPropertyList();
+	}
+
+	onClose(): void {
+		this.suggest?.close();
+		this.suggest = null;
+		this.contentEl.empty();
+		this.options.onDismiss?.();
+	}
+
+	private discoverProperties(): string[] {
+		this.plugin.index.ensureCurrent();
+		const properties = new Map<string, string>();
+		for (const file of this.app.vault.getMarkdownFiles()) {
+			if (this.plugin.index.keyForPath(file.path) === null) continue;
+			const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+			if (!frontmatter) continue;
+			for (const rawName of Object.keys(frontmatter)) {
+				const name = rawName.trim();
+				const key = name.toLocaleLowerCase();
+				if (!name || key === "tags" || key === "position" || properties.has(key)) continue;
+				properties.set(key, name);
+			}
+		}
+		return Array.from(properties.values()).sort((left, right) => left.localeCompare(right));
+	}
+
+	private availableProperties(): string[] {
+		const selected = new Set(this.plugin.settings.displayProperties.map((name) => name.toLocaleLowerCase()));
+		return this.knownProperties.filter((name) => !selected.has(name.toLocaleLowerCase()));
+	}
+
+	private syncAddButton(value: string): void {
+		this.addButton.disabled = value.trim().length === 0;
+	}
+
+	private addProperty(rawName: string): void {
+		const name = rawName.trim();
+		if (!name) return;
+		const key = name.toLocaleLowerCase();
+		if (key === "tags") {
+			new Notice('Use the "display tags" toggle to show tags.');
+			return;
+		}
+		if (this.plugin.settings.displayProperties.some((current) => current.toLocaleLowerCase() === key)) {
+			new Notice(`Property "${name}" is already displayed.`);
+			return;
+		}
+
+		this.plugin.settings.displayProperties = [...this.plugin.settings.displayProperties, name];
+		this.propertyInput.value = "";
+		this.syncAddButton("");
+		this.renderPropertyList();
+		this.persist();
+	}
+
+	private removeProperty(index: number): void {
+		this.plugin.settings.displayProperties = this.plugin.settings.displayProperties.filter(
+			(_name, current) => current !== index,
+		);
+		this.renderPropertyList();
+		this.persist();
+	}
+
+	private renderPropertyList(): void {
+		this.propertyList.empty();
+		const properties = this.plugin.settings.displayProperties;
+		if (!properties.length) {
+			this.propertyList.createDiv({
+				cls: "setting-item-description journal-appearance-empty",
+				text: "No properties selected.",
+			});
+			return;
+		}
+
+		properties.forEach((name, index) => {
+			new Setting(this.propertyList).setName(name).addExtraButton((button) =>
+				button
+					.setIcon("x")
+					.setTooltip(`Stop displaying ${name}`)
+					.onClick(() => this.removeProperty(index)),
+			);
+		});
+	}
+
+	private persist(): void {
+		this.plugin.notifyViewsImmediately();
+		this.saving = this.saving
+			.then(() => this.plugin.saveSettings(false))
+			.catch((error: unknown) => {
+				console.error("Journal View: could not save appearance settings", error);
+				new Notice("Journal view: could not save appearance settings");
+			});
+	}
+}

--- a/src/appearance.ts
+++ b/src/appearance.ts
@@ -5,6 +5,11 @@ interface AppearanceModalOptions {
 	onDismiss?(): void;
 }
 
+interface SettingsController {
+	open(): void;
+	openTabById(id: string): void;
+}
+
 /** Autocomplete attached to the property-name field. */
 class PropertySuggest extends AbstractInputSuggest<string> {
 	constructor(
@@ -122,6 +127,16 @@ export class AppearanceModal extends Modal {
 
 		this.propertyList = this.contentEl.createDiv({ cls: "journal-appearance-properties" });
 		this.renderPropertyList();
+
+		const settingsLink = this.contentEl.createEl("button", {
+			cls: "journal-appearance-settings-link",
+			text: "Open all settings",
+			attr: { type: "button" },
+		});
+		settingsLink.addEventListener("click", (event) => {
+			event.preventDefault();
+			this.openPluginSettings();
+		});
 	}
 
 	onClose(): void {
@@ -204,6 +219,17 @@ export class AppearanceModal extends Modal {
 					.onClick(() => this.removeProperty(index)),
 			);
 		});
+	}
+
+	private openPluginSettings(): void {
+		const settings = (this.app as App & { setting?: SettingsController }).setting;
+		if (!settings) {
+			new Notice("Journal view: could not open plugin settings");
+			return;
+		}
+		this.close();
+		settings.open();
+		settings.openTabById(this.plugin.manifest.id);
 	}
 
 	private persist(): void {

--- a/src/appearance.ts
+++ b/src/appearance.ts
@@ -1,4 +1,4 @@
-import { AbstractInputSuggest, App, Modal, Notice, Setting } from "obsidian";
+import { AbstractInputSuggest, App, Modal, Notice, Setting, setIcon } from "obsidian";
 import type JournalViewPlugin from "./main";
 
 interface AppearanceModalOptions {
@@ -54,7 +54,7 @@ export class AppearanceModal extends Modal {
 		this.titleEl.setText("Customization");
 		this.knownProperties = this.discoverProperties();
 
-		new Setting(this.contentEl)
+		const tagsSetting = new Setting(this.contentEl)
 			.setName("Display tags")
 			.setDesc("Show tags from each daily note's frontmatter above its body.")
 			.addToggle((toggle) =>
@@ -63,10 +63,23 @@ export class AppearanceModal extends Modal {
 					this.persist();
 				}),
 			);
+		tagsSetting.nameEl.addClass("journal-appearance-setting-name");
+		const tagsIcon = tagsSetting.nameEl.createSpan({ cls: "journal-appearance-setting-icon" });
+		setIcon(tagsIcon, "tags");
+		tagsIcon.setAttribute("aria-hidden", "true");
+		tagsSetting.nameEl.prepend(tagsIcon);
 
-		new Setting(this.contentEl)
+		const propertiesSetting = new Setting(this.contentEl)
 			.setName("Properties")
-			.setDesc("Choose frontmatter properties to show on every existing daily note.");
+			.setDesc("Choose frontmatter properties to show on every existing daily note.")
+			.setClass("journal-appearance-properties-heading");
+		propertiesSetting.nameEl.addClass("journal-appearance-setting-name");
+		const propertiesIcon = propertiesSetting.nameEl.createSpan({
+			cls: "journal-appearance-setting-icon",
+		});
+		setIcon(propertiesIcon, "list-tree");
+		propertiesIcon.setAttribute("aria-hidden", "true");
+		propertiesSetting.nameEl.prepend(propertiesIcon);
 
 		const add = new Setting(this.contentEl).setName("Add property");
 		add.settingEl.addClass("journal-appearance-add-property");

--- a/src/appearance.ts
+++ b/src/appearance.ts
@@ -55,7 +55,7 @@ export class AppearanceModal extends Modal {
 		this.knownProperties = this.discoverProperties();
 
 		const tagsSetting = new Setting(this.contentEl)
-			.setName("Display tags")
+			.setName("Tags")
 			.setDesc("Show tags from each daily note's frontmatter above its body.")
 			.addToggle((toggle) =>
 				toggle.setValue(this.plugin.settings.showTags).onChange((value) => {

--- a/src/day.ts
+++ b/src/day.ts
@@ -73,7 +73,7 @@ class JournalTagSuggest extends AbstractInputSuggest<string> {
 	}
 
 	renderSuggestion(value: string, el: HTMLElement): void {
-		el.setText(`#${value}`);
+		el.setText(value);
 	}
 
 	selectSuggestion(value: string): void {
@@ -220,12 +220,28 @@ function parsePropertyDraft(kind: PropertyEditKind, draft: string): ParsedProper
 		}
 	}
 
-	return { valid: true, remove: false, value: draft };
+	return { valid: true, remove: false, value: trimmed };
 }
 
 function normalizedTag(raw: string): string | null {
 	const tag = raw.trim().replace(/^#+/, "");
 	return tag && !/[\s,]/.test(tag) ? tag : null;
+}
+
+function sameMetadataValue(left: unknown, right: unknown): boolean {
+	if (Object.is(left, right)) return true;
+	if ((!Array.isArray(left) && !isRecord(left)) || (!Array.isArray(right) && !isRecord(right))) {
+		return false;
+	}
+	try {
+		return JSON.stringify(left) === JSON.stringify(right);
+	} catch {
+		return false;
+	}
+}
+
+function storedTagMatches(value: unknown, target: string): boolean {
+	return typeof value === "string" && normalizedTag(value)?.toLocaleLowerCase() === target;
 }
 
 function sameFindRange(left: FindRange | null, right: FindRange | null): boolean {
@@ -291,7 +307,8 @@ export class DaySection {
 	private tagEdit: TagEditState | null = null;
 	private tagSuggest: JournalTagSuggest | null = null;
 	private refreshingMetadata = false;
-	private tagBlurTimer = 0;
+	private tagPointerCleanup: (() => void) | null = null;
+	private tagSuggestionPointerDown = false;
 	private metadataWrites: Promise<void> = Promise.resolve();
 	private pendingProperties = new Set<string>();
 	private tagsPending = false;
@@ -564,8 +581,9 @@ export class DaySection {
 		if (this.destroyed) return;
 		this.latestContent = content;
 		this.captureMetadataEdit();
-		window.clearTimeout(this.tagBlurTimer);
-		this.tagBlurTimer = 0;
+		this.tagPointerCleanup?.();
+		this.tagPointerCleanup = null;
+		this.tagSuggestionPointerDown = false;
 		this.refreshingMetadata = true;
 		this.tagSuggest?.close();
 		this.tagSuggest = null;
@@ -600,11 +618,13 @@ export class DaySection {
 				if (this.propertyEdit?.property.toLocaleLowerCase() === key) {
 					this.renderPropertyEditor(row, this.propertyEdit);
 				} else {
+					const valueText = metadataText(entry?.[1]);
 					const value = row.createEl("button", {
 						cls: "journal-day-metadata-value journal-day-metadata-value-button",
-						text: metadataText(entry?.[1]),
+						text: valueText,
 						attr: { type: "button", "aria-label": `Edit ${property}` },
 					});
+					value.toggleClass("journal-day-metadata-value-empty", valueText === "—");
 					value.disabled = pending;
 					value.addEventListener("click", (event) => {
 						event.stopPropagation();
@@ -658,8 +678,9 @@ export class DaySection {
 			this.commitPropertyEdit(this.propertyEdit);
 			if (this.propertyEdit) return; // invalid input stays open until corrected or cancelled
 		}
-		window.clearTimeout(this.tagBlurTimer);
-		this.tagBlurTimer = 0;
+		this.tagPointerCleanup?.();
+		this.tagPointerCleanup = null;
+		this.tagSuggestionPointerDown = false;
 		this.tagSuggest?.close();
 		this.tagSuggest = null;
 		this.tagEdit = null;
@@ -683,11 +704,12 @@ export class DaySection {
 		const input = editor.createEl("input", {
 			cls: "journal-day-property-input",
 			attr: {
-				type: state.kind === "number" ? "number" : state.kind === "boolean" ? "checkbox" : "text",
+				type: state.kind === "boolean" ? "checkbox" : "text",
 				"aria-label": `Edit ${state.property}`,
 			},
 		});
 		state.inputEl = input;
+		if (state.kind === "number") input.inputMode = "decimal";
 		if (state.kind === "boolean") input.checked = state.draft === "true";
 		else input.value = state.draft;
 		this.syncInvalidMetadataInput(input, state.invalid);
@@ -711,15 +733,14 @@ export class DaySection {
 				state.draft = String(input.checked);
 				this.commitPropertyEdit(state);
 			});
-		} else {
-			input.addEventListener("blur", (event) => {
-				const related = event.relatedTarget as Node | null;
-				if (this.refreshingMetadata || editor.contains(related)) return;
-				window.setTimeout(() => {
-					if (this.propertyEdit === state && !this.refreshingMetadata) this.commitPropertyEdit(state);
-				}, 0);
-			});
 		}
+		input.addEventListener("blur", (event) => {
+			const related = event.relatedTarget as Node | null;
+			if (this.refreshingMetadata || editor.contains(related)) return;
+			window.setTimeout(() => {
+				if (this.propertyEdit === state && !this.refreshingMetadata) this.commitPropertyEdit(state);
+			}, 0);
+		});
 
 		const clear = editor.createEl("button", {
 			cls: "clickable-icon journal-day-metadata-clear",
@@ -749,12 +770,23 @@ export class DaySection {
 
 	private commitPropertyEdit(state: PropertyEditState, forceRemove = false): void {
 		if (this.propertyEdit !== state) return;
+		const draft = state.inputEl?.type === "checkbox" ? String(state.inputEl.checked) : state.draft;
+		if (!forceRemove && this.propertyDraftUnchanged(state.property, state.kind, draft)) {
+			this.propertyEdit = null;
+			this.refreshMetadata();
+			return;
+		}
 		const parsed = forceRemove
 			? { valid: true, remove: true }
-			: parsePropertyDraft(state.kind, state.inputEl?.type === "checkbox" ? String(state.inputEl.checked) : state.draft);
+			: parsePropertyDraft(state.kind, draft);
 		if (!parsed.valid) {
 			state.invalid = parsed.error ?? "Enter a valid value.";
 			if (state.inputEl) this.syncInvalidMetadataInput(state.inputEl, state.invalid);
+			return;
+		}
+		if (!this.propertyWriteNeeded(state.property, parsed.remove, parsed.value)) {
+			this.propertyEdit = null;
+			this.refreshMetadata();
 			return;
 		}
 
@@ -766,6 +798,22 @@ export class DaySection {
 			this.pendingProperties.delete(pendingKey);
 			if (!this.destroyed) this.refreshMetadata();
 		});
+	}
+
+	private propertyWriteNeeded(property: string, remove: boolean, value: unknown): boolean {
+		const frontmatter = this.parseFrontmatter(this.latestContent);
+		const entry = Object.entries(frontmatter).find(
+			([key]) => key.toLocaleLowerCase() === property.toLocaleLowerCase(),
+		);
+		return remove ? entry !== undefined : !entry || !sameMetadataValue(entry[1], value);
+	}
+
+	private propertyDraftUnchanged(property: string, kind: PropertyEditKind, draft: string): boolean {
+		const frontmatter = this.parseFrontmatter(this.latestContent);
+		const entry = Object.entries(frontmatter).find(
+			([key]) => key.toLocaleLowerCase() === property.toLocaleLowerCase(),
+		);
+		return !!entry && propertyDraft(entry[1], kind) === draft;
 	}
 
 	private renderTags(frontmatter: Record<string, unknown>): void {
@@ -784,14 +832,15 @@ export class DaySection {
 		const list = row.createDiv({ cls: "journal-day-tags" });
 
 		for (const tag of tags) {
-			const chip = list.createEl("button", {
-				cls: "journal-day-tag journal-day-tag-remove",
+			const chip = list.createSpan({ cls: "journal-day-tag" });
+			chip.createSpan({ cls: "journal-day-tag-text", text: tag });
+			const remove = chip.createEl("button", {
+				cls: "journal-day-tag-remove",
 				attr: { type: "button", "aria-label": `Remove tag ${tag}` },
 			});
-			chip.createSpan({ text: `#${tag}` });
-			chip.createSpan({ cls: "journal-day-tag-x", text: "×", attr: { "aria-hidden": "true" } });
-			chip.disabled = this.tagsPending;
-			chip.addEventListener("click", (event) => {
+			remove.createSpan({ text: "×", attr: { "aria-hidden": "true" } });
+			remove.disabled = this.tagsPending;
+			remove.addEventListener("click", (event) => {
 				event.stopPropagation();
 				this.removeTag(tag);
 			});
@@ -844,11 +893,18 @@ export class DaySection {
 			input,
 			() => state.suggestions,
 			(value) => {
-				window.clearTimeout(this.tagBlurTimer);
-				this.tagBlurTimer = 0;
 				this.commitTag(state, value, currentTags);
 			},
 		);
+		const document = input.ownerDocument;
+		const onPointerDown = (event: PointerEvent): void => {
+			const target = event.target instanceof Element ? event.target : null;
+			if (target?.closest(".suggestion-container")) {
+				this.tagSuggestionPointerDown = true;
+			}
+		};
+		document.addEventListener("pointerdown", onPointerDown, true);
+		this.tagPointerCleanup = () => document.removeEventListener("pointerdown", onPointerDown, true);
 		input.addEventListener("input", () => {
 			state.draft = input.value;
 			state.invalid = null;
@@ -865,20 +921,23 @@ export class DaySection {
 		});
 		input.addEventListener("blur", () => {
 			if (this.refreshingMetadata) return;
-			window.clearTimeout(this.tagBlurTimer);
-			this.tagBlurTimer = window.setTimeout(() => {
-				this.tagBlurTimer = 0;
+			window.setTimeout(() => {
+				if (this.tagSuggestionPointerDown) {
+					this.tagSuggestionPointerDown = false;
+					return;
+				}
 				if (this.tagEdit === state && state.inputEl === input && input.ownerDocument.activeElement !== input) {
 					this.cancelTagEdit(state);
 				}
-			}, 150);
+			}, 0);
 		});
 	}
 
 	private cancelTagEdit(state: TagEditState): void {
 		if (this.tagEdit !== state) return;
-		window.clearTimeout(this.tagBlurTimer);
-		this.tagBlurTimer = 0;
+		this.tagPointerCleanup?.();
+		this.tagPointerCleanup = null;
+		this.tagSuggestionPointerDown = false;
 		this.tagSuggest?.close();
 		this.tagSuggest = null;
 		this.tagEdit = null;
@@ -894,13 +953,14 @@ export class DaySection {
 			return;
 		}
 		if (currentTags.some((current) => current.toLocaleLowerCase() === tag.toLocaleLowerCase())) {
-			state.invalid = `#${tag} is already present.`;
+			state.invalid = `${tag} is already present.`;
 			if (state.inputEl) this.syncInvalidMetadataInput(state.inputEl, state.invalid);
 			return;
 		}
 
-		window.clearTimeout(this.tagBlurTimer);
-		this.tagBlurTimer = 0;
+		this.tagPointerCleanup?.();
+		this.tagPointerCleanup = null;
+		this.tagSuggestionPointerDown = false;
 		this.tagSuggest?.close();
 		this.tagSuggest = null;
 		this.tagEdit = null;
@@ -939,6 +999,7 @@ export class DaySection {
 	}
 
 	private writeProperty(property: string, remove: boolean, value: unknown): Promise<void> {
+		if (!this.propertyWriteNeeded(property, remove, value)) return Promise.resolve();
 		return this.enqueueMetadataWrite(`update ${property}`, (frontmatter) => {
 			const actual = Object.keys(frontmatter).find(
 				(key) => key.toLocaleLowerCase() === property.toLocaleLowerCase(),
@@ -952,19 +1013,46 @@ export class DaySection {
 	}
 
 	private writeTag(action: "add" | "remove", tag: string): Promise<void> {
+		if (!this.tagWriteNeeded(action, tag)) return Promise.resolve();
 		return this.enqueueMetadataWrite(`${action} tag ${tag}`, (frontmatter) => {
 			const actual = Object.keys(frontmatter).find((key) => key.toLocaleLowerCase() === "tags");
-			const tags = this.frontmatterTags(frontmatter);
 			const target = tag.toLocaleLowerCase();
-			const next =
-				action === "add"
-					? tags.some((current) => current.toLocaleLowerCase() === target)
-						? tags
-						: [...tags, tag]
-					: tags.filter((current) => current.toLocaleLowerCase() !== target);
-			if (next.length) frontmatter[actual ?? "tags"] = next;
-			else if (actual) delete frontmatter[actual];
+			if (!actual) {
+				if (action === "add") frontmatter.tags = [tag];
+				return;
+			}
+
+			const stored = frontmatter[actual];
+			if (Array.isArray(stored)) {
+				if (action === "add") {
+					if (!stored.some((value) => storedTagMatches(value, target))) stored.push(tag);
+				} else {
+					for (let index = stored.length - 1; index >= 0; index--) {
+						if (storedTagMatches(stored[index], target)) stored.splice(index, 1);
+					}
+					if (!stored.length) delete frontmatter[actual];
+				}
+				return;
+			}
+
+			if (action === "add") {
+				if (!storedTagMatches(stored, target)) frontmatter[actual] = [stored, tag];
+			} else if (storedTagMatches(stored, target)) {
+				delete frontmatter[actual];
+			}
 		});
+	}
+
+	private tagWriteNeeded(action: "add" | "remove", tag: string): boolean {
+		const frontmatter = this.parseFrontmatter(this.latestContent);
+		const actual = Object.keys(frontmatter).find((key) => key.toLocaleLowerCase() === "tags");
+		if (!actual) return action === "add";
+		const stored = frontmatter[actual];
+		const target = tag.toLocaleLowerCase();
+		const present = Array.isArray(stored)
+			? stored.some((value) => storedTagMatches(value, target))
+			: storedTagMatches(stored, target);
+		return action === "add" ? !present : present;
 	}
 
 	private enqueueMetadataWrite(
@@ -1613,8 +1701,9 @@ export class DaySection {
 		this.destroyed = true;
 		this.focusSettleToken++;
 		window.clearTimeout(this.saveTimer);
-		window.clearTimeout(this.tagBlurTimer);
-		this.tagBlurTimer = 0;
+		this.tagPointerCleanup?.();
+		this.tagPointerCleanup = null;
+		this.tagSuggestionPointerDown = false;
 		this.tagSuggest?.close();
 		this.tagSuggest = null;
 		this.propertyEdit = null;

--- a/src/day.ts
+++ b/src/day.ts
@@ -49,12 +49,26 @@ interface TagEditState {
 	selectionEnd: number | null;
 }
 
+interface PropertyListEditState {
+	property: string;
+	draft: string;
+	invalid: string | null;
+	inputEl: HTMLInputElement | null;
+	wasFocused: boolean;
+	selectionStart: number | null;
+	selectionEnd: number | null;
+}
+
 interface ParsedPropertyDraft {
 	valid: boolean;
 	remove: boolean;
 	value?: unknown;
 	error?: string;
 }
+
+type PropertyListMutation =
+	| { action: "add"; value: string }
+	| { action: "remove"; index: number; value: unknown };
 
 /** Autocomplete for the tag input inside a day's metadata strip. */
 class JournalTagSuggest extends AbstractInputSuggest<string> {
@@ -304,6 +318,7 @@ export class DaySection {
 	/** Newest complete file content, including external frontmatter held off from a dirty editor. */
 	private latestContent = "";
 	private propertyEdit: PropertyEditState | null = null;
+	private propertyListEdit: PropertyListEditState | null = null;
 	private tagEdit: TagEditState | null = null;
 	private tagSuggest: JournalTagSuggest | null = null;
 	private refreshingMetadata = false;
@@ -594,6 +609,7 @@ export class DaySection {
 			const { displayProperties, showTags } = this.host.plugin.settings;
 			if (!this.file || (!displayProperties.length && !showTags)) {
 				this.propertyEdit = null;
+				this.propertyListEdit = null;
 				this.tagEdit = null;
 				return;
 			}
@@ -601,6 +617,12 @@ export class DaySection {
 			const displayed = new Set(displayProperties.map((property) => property.toLocaleLowerCase()));
 			if (this.propertyEdit && !displayed.has(this.propertyEdit.property.toLocaleLowerCase())) {
 				this.propertyEdit = null;
+			}
+			if (
+				this.propertyListEdit &&
+				!displayed.has(this.propertyListEdit.property.toLocaleLowerCase())
+			) {
+				this.propertyListEdit = null;
 			}
 			if (!showTags) this.tagEdit = null;
 
@@ -612,13 +634,22 @@ export class DaySection {
 				const row = this.metadataEl.createDiv({ cls: "journal-day-metadata-row" });
 				row.createSpan({ cls: "journal-day-metadata-label", text: property });
 				const pending = this.pendingProperties.has(key);
+				const propertyValue = entry?.[1];
+				if (
+					this.propertyListEdit?.property.toLocaleLowerCase() === key &&
+					!Array.isArray(propertyValue)
+				) {
+					this.propertyListEdit = null;
+				}
 				row.toggleClass("journal-day-metadata-pending", pending);
 				if (pending) row.setAttribute("aria-busy", "true");
 
 				if (this.propertyEdit?.property.toLocaleLowerCase() === key) {
 					this.renderPropertyEditor(row, this.propertyEdit);
+				} else if (Array.isArray(propertyValue)) {
+					this.renderPropertyList(row, property, propertyValue, pending);
 				} else {
-					const valueText = metadataText(entry?.[1]);
+					const valueText = metadataText(propertyValue);
 					const value = row.createEl("button", {
 						cls: "journal-day-metadata-value journal-day-metadata-value-button",
 						text: valueText,
@@ -628,7 +659,7 @@ export class DaySection {
 					value.disabled = pending;
 					value.addEventListener("click", (event) => {
 						event.stopPropagation();
-						this.startPropertyEdit(property, entry?.[1]);
+						this.startPropertyEdit(property, propertyValue);
 					});
 				}
 			}
@@ -641,9 +672,156 @@ export class DaySection {
 		}
 	}
 
+	private renderPropertyList(
+		row: HTMLElement,
+		property: string,
+		items: unknown[],
+		pending: boolean,
+	): void {
+		row.addClass("journal-day-metadata-list");
+		const list = row.createDiv({
+			cls: "journal-day-property-list",
+			attr: { "aria-label": `${property} values` },
+		});
+		for (const [index, item] of items.entries()) {
+			const text = nestedMetadataText(item) || "—";
+			const chip = list.createSpan({ cls: "journal-day-tag journal-day-property-list-item" });
+			chip.createSpan({ cls: "journal-day-tag-text", text });
+			const remove = chip.createEl("button", {
+				cls: "journal-day-tag-remove",
+				attr: { type: "button", "aria-label": `Remove ${text} from ${property}` },
+			});
+			remove.createSpan({ text: "×", attr: { "aria-hidden": "true" } });
+			remove.disabled = pending;
+			remove.addEventListener("click", (event) => {
+				event.stopPropagation();
+				this.removePropertyListItem(property, index, item);
+			});
+		}
+
+		if (this.propertyListEdit?.property.toLocaleLowerCase() === property.toLocaleLowerCase()) {
+			this.renderPropertyListEditor(list, this.propertyListEdit, pending);
+		} else {
+			const add = list.createEl("button", {
+				cls: "clickable-icon journal-day-tag-add journal-day-property-list-add",
+				attr: { type: "button", "aria-label": `Add item to ${property}` },
+			});
+			setIcon(add, "plus");
+			setTooltip(add, `Add item to ${property}`);
+			add.disabled = pending;
+			add.addEventListener("click", (event) => {
+				event.stopPropagation();
+				this.startPropertyListEdit(property);
+			});
+		}
+	}
+
+	private startPropertyListEdit(property: string): void {
+		if (!this.file || this.pendingProperties.has(property.toLocaleLowerCase())) return;
+		if (this.propertyEdit) {
+			this.commitPropertyEdit(this.propertyEdit);
+			if (this.propertyEdit) return;
+		}
+		this.tagPointerCleanup?.();
+		this.tagPointerCleanup = null;
+		this.tagSuggestionPointerDown = false;
+		this.tagSuggest?.close();
+		this.tagSuggest = null;
+		this.tagEdit = null;
+		this.propertyListEdit = {
+			property,
+			draft: "",
+			invalid: null,
+			inputEl: null,
+			wasFocused: true,
+			selectionStart: 0,
+			selectionEnd: 0,
+		};
+		this.refreshMetadata();
+	}
+
+	private renderPropertyListEditor(
+		list: HTMLElement,
+		state: PropertyListEditState,
+		pending: boolean,
+	): void {
+		const input = list.createEl("input", {
+			cls: "journal-day-tag-input journal-day-property-list-input",
+			attr: {
+				type: "text",
+				placeholder: "Add item",
+				"aria-label": `Add item to ${state.property}`,
+			},
+		});
+		input.value = state.draft;
+		input.readOnly = pending;
+		state.inputEl = input;
+		this.syncInvalidMetadataInput(input, state.invalid);
+		input.addEventListener("input", () => {
+			state.draft = input.value;
+			state.invalid = null;
+			this.syncInvalidMetadataInput(input, null);
+		});
+		input.addEventListener("keydown", (event) => {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				this.cancelPropertyListEdit(state);
+			} else if (event.key === "Enter") {
+				event.preventDefault();
+				this.commitPropertyListItem(state);
+			}
+		});
+		input.addEventListener("blur", () => {
+			if (this.refreshingMetadata) return;
+			window.setTimeout(() => {
+				if (
+					this.propertyListEdit === state &&
+					state.inputEl === input &&
+					input.ownerDocument.activeElement !== input
+				) {
+					this.cancelPropertyListEdit(state);
+				}
+			}, 0);
+		});
+	}
+
+	private cancelPropertyListEdit(state: PropertyListEditState): void {
+		if (this.propertyListEdit !== state) return;
+		this.propertyListEdit = null;
+		this.refreshMetadata();
+	}
+
+	private commitPropertyListItem(state: PropertyListEditState): void {
+		if (this.propertyListEdit !== state) return;
+		const value = state.draft.trim();
+		if (!value) {
+			state.invalid = "Enter a list item.";
+			if (state.inputEl) this.syncInvalidMetadataInput(state.inputEl, state.invalid);
+			return;
+		}
+		this.propertyListEdit = null;
+		this.updatePropertyList(state.property, { action: "add", value });
+	}
+
+	private removePropertyListItem(property: string, index: number, value: unknown): void {
+		if (this.pendingProperties.has(property.toLocaleLowerCase())) return;
+		this.updatePropertyList(property, { action: "remove", index, value });
+	}
+
+	private updatePropertyList(property: string, mutation: PropertyListMutation): void {
+		const pendingKey = property.toLocaleLowerCase();
+		if (this.pendingProperties.has(pendingKey)) return;
+		this.pendingProperties.add(pendingKey);
+		this.refreshMetadata();
+		void this.writePropertyList(property, mutation).finally(() => {
+			this.pendingProperties.delete(pendingKey);
+			if (!this.destroyed) this.refreshMetadata();
+		});
+	}
+
 	private captureMetadataEdit(): void {
 		const active = this.metadataEl.ownerDocument.activeElement;
-		for (const state of [this.propertyEdit, this.tagEdit]) {
+		for (const state of [this.propertyEdit, this.propertyListEdit, this.tagEdit]) {
 			const input = state?.inputEl;
 			if (!state || !input) continue;
 			if (input.type === "checkbox") state.draft = String(input.checked);
@@ -657,7 +835,7 @@ export class DaySection {
 	}
 
 	private restoreMetadataFocus(): void {
-		for (const state of [this.propertyEdit, this.tagEdit]) {
+		for (const state of [this.propertyEdit, this.propertyListEdit, this.tagEdit]) {
 			if (!state?.wasFocused || !state.inputEl) continue;
 			const input = state.inputEl;
 			window.requestAnimationFrame(() => {
@@ -684,6 +862,7 @@ export class DaySection {
 		this.tagSuggest?.close();
 		this.tagSuggest = null;
 		this.tagEdit = null;
+		this.propertyListEdit = null;
 		const kind = propertyEditKind(value);
 		this.propertyEdit = {
 			property,
@@ -713,11 +892,16 @@ export class DaySection {
 		if (state.kind === "boolean") input.checked = state.draft === "true";
 		else input.value = state.draft;
 		this.syncInvalidMetadataInput(input, state.invalid);
+		window.requestAnimationFrame(() => {
+			if (this.destroyed || !input.isConnected || state.inputEl !== input) return;
+			this.resizePropertyInput(input);
+		});
 
 		input.addEventListener("input", () => {
 			state.draft = input.type === "checkbox" ? String(input.checked) : input.value;
 			state.invalid = null;
 			this.syncInvalidMetadataInput(input, null);
+			this.resizePropertyInput(input);
 		});
 		input.addEventListener("keydown", (event) => {
 			if (event.key === "Escape") {
@@ -753,6 +937,13 @@ export class DaySection {
 			event.stopPropagation();
 			this.commitPropertyEdit(state, true);
 		});
+	}
+
+	private resizePropertyInput(input: HTMLInputElement): void {
+		if (input.type === "checkbox") return;
+		input.setCssProps({ "--journal-property-input-width": "0px" });
+		const borderWidth = input.offsetWidth - input.clientWidth;
+		input.setCssProps({ "--journal-property-input-width": `${input.scrollWidth + borderWidth}px` });
 	}
 
 	private syncInvalidMetadataInput(input: HTMLInputElement, error: string | null): void {
@@ -868,6 +1059,7 @@ export class DaySection {
 			this.commitPropertyEdit(this.propertyEdit);
 			if (this.propertyEdit) return;
 		}
+		this.propertyListEdit = null;
 		this.tagEdit = {
 			draft: "",
 			invalid: null,
@@ -1010,6 +1202,47 @@ export class DaySection {
 				frontmatter[actual ?? property] = value;
 			}
 		});
+	}
+
+	private writePropertyList(property: string, mutation: PropertyListMutation): Promise<void> {
+		if (!this.propertyListWriteNeeded(property, mutation)) return Promise.resolve();
+		return this.enqueueMetadataWrite(`update ${property}`, (frontmatter) => {
+			const actual = Object.keys(frontmatter).find(
+				(key) => key.toLocaleLowerCase() === property.toLocaleLowerCase(),
+			);
+			if (!actual) {
+				if (mutation.action === "add") frontmatter[property] = [mutation.value];
+				return;
+			}
+
+			const stored = frontmatter[actual];
+			if (!Array.isArray(stored)) throw new Error(`${actual} is no longer a list`);
+			if (mutation.action === "add") {
+				stored.push(mutation.value);
+				return;
+			}
+
+			let index = mutation.index;
+			if (!sameMetadataValue(stored[index], mutation.value)) {
+				index = stored.findIndex((item) => sameMetadataValue(item, mutation.value));
+			}
+			if (index >= 0) stored.splice(index, 1);
+		});
+	}
+
+	private propertyListWriteNeeded(property: string, mutation: PropertyListMutation): boolean {
+		const frontmatter = this.parseFrontmatter(this.latestContent);
+		const actual = Object.keys(frontmatter).find(
+			(key) => key.toLocaleLowerCase() === property.toLocaleLowerCase(),
+		);
+		if (!actual) return mutation.action === "add";
+		const stored = frontmatter[actual];
+		if (!Array.isArray(stored)) return false;
+		if (mutation.action === "add") return true;
+		return (
+			sameMetadataValue(stored[mutation.index], mutation.value) ||
+			stored.some((item) => sameMetadataValue(item, mutation.value))
+		);
 	}
 
 	private writeTag(action: "add" | "remove", tag: string): Promise<void> {
@@ -1707,6 +1940,7 @@ export class DaySection {
 		this.tagSuggest?.close();
 		this.tagSuggest = null;
 		this.propertyEdit = null;
+		this.propertyListEdit = null;
 		this.tagEdit = null;
 		this.stopRevealing();
 		// Anything unsaved goes to the queue, which outlives this object.

--- a/src/day.ts
+++ b/src/day.ts
@@ -1,4 +1,15 @@
-import { App, Component, MarkdownRenderer, Notice, TFile, getFrontMatterInfo, setIcon, setTooltip } from "obsidian";
+import {
+	App,
+	Component,
+	MarkdownRenderer,
+	Notice,
+	TFile,
+	getFrontMatterInfo,
+	parseFrontMatterTags,
+	parseYaml,
+	setIcon,
+	setTooltip,
+} from "obsidian";
 import type JournalViewPlugin from "./main";
 import { JournalEditor, createJournalEditor } from "./editor";
 import type { Moment } from "./moment";
@@ -48,6 +59,32 @@ function replaceNoteBody(content: string, body: string): string {
 	return content.slice(0, getFrontMatterInfo(content).contentStart) + body;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nestedMetadataText(value: unknown): string {
+	if (value === null || value === undefined) return "";
+	if (typeof value === "string") return value.trim();
+	if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+		return String(value);
+	}
+	try {
+		return JSON.stringify(value) ?? "";
+	} catch {
+		return "";
+	}
+}
+
+/** Compact, non-interactive rendering for a frontmatter value. */
+function metadataText(value: unknown): string {
+	if (Array.isArray(value)) {
+		const items = value.map(nestedMetadataText).filter(Boolean);
+		return items.length ? items.join(", ") : "—";
+	}
+	return nestedMetadataText(value) || "—";
+}
+
 function sameFindRange(left: FindRange | null, right: FindRange | null): boolean {
 	return left === right || (!!left && !!right && left.from === right.from && left.to === right.to);
 }
@@ -83,6 +120,7 @@ export class DaySection {
 	private headerEl: HTMLElement;
 	private titleEl: HTMLElement;
 	private actionsEl: HTMLElement;
+	private metadataEl: HTMLElement;
 	private bodyEl: HTMLElement;
 
 	private editor: JournalEditor | null = null;
@@ -104,6 +142,8 @@ export class DaySection {
 	private endReveal: (() => void) | null = null;
 
 	private lastKnownContent = "";
+	/** Newest complete file content, including external frontmatter held off from a dirty editor. */
+	private latestContent = "";
 	/** An external write held off until this day's own pending edit has settled. */
 	private externalReloadPending = false;
 	/** Template text shown in an empty day but not yet accepted by the reader. */
@@ -154,6 +194,8 @@ export class DaySection {
 		if (relative) this.titleEl.createSpan({ cls: "journal-day-badge", text: relative });
 		this.actionsEl = this.headerEl.createDiv({ cls: "journal-day-actions" });
 
+		this.metadataEl = this.cardEl.createDiv({ cls: "journal-day-metadata" });
+		this.metadataEl.hidden = true;
 		this.bodyEl = this.cardEl.createDiv({ cls: "journal-day-body" });
 
 		this.el.addEventListener("click", (event) => this.onClick(event));
@@ -363,6 +405,78 @@ export class DaySection {
 				void this.createNow();
 			});
 		}
+		this.refreshMetadata();
+	}
+
+	/** Rebuilds the read-only strip from the latest complete note content. */
+	refreshMetadata(content = this.latestContent): void {
+		if (this.destroyed) return;
+		this.latestContent = content;
+		this.metadataEl.empty();
+		this.metadataEl.hidden = true;
+		const { displayProperties, showTags } = this.host.plugin.settings;
+		if (!this.file || (!displayProperties.length && !showTags)) return;
+
+		const frontmatter = this.parseFrontmatter(content);
+		const entries = Object.entries(frontmatter);
+		for (const property of displayProperties) {
+			const key = property.toLocaleLowerCase();
+			const entry = entries.find(([name]) => name.toLocaleLowerCase() === key);
+			const row = this.metadataEl.createDiv({ cls: "journal-day-metadata-row" });
+			row.createSpan({ cls: "journal-day-metadata-label", text: property });
+			row.createSpan({ cls: "journal-day-metadata-value", text: metadataText(entry?.[1]) });
+		}
+
+		if (showTags) {
+			const tags = this.frontmatterTags(frontmatter);
+			if (tags.length) {
+				const row = this.metadataEl.createDiv({
+					cls: "journal-day-metadata-row journal-day-metadata-tags",
+				});
+				const label = row.createSpan({
+					cls: "journal-day-metadata-label journal-day-metadata-tags-label",
+				});
+				setIcon(label, "tag");
+				label.querySelector("svg")?.setAttribute("aria-hidden", "true");
+				setTooltip(label, "Tags");
+				const list = row.createDiv({ cls: "journal-day-tags" });
+				for (const tag of tags) list.createSpan({ cls: "journal-day-tag", text: `#${tag}` });
+			}
+		}
+
+		this.metadataEl.hidden = this.metadataEl.childElementCount === 0;
+	}
+
+	private parseFrontmatter(content: string): Record<string, unknown> {
+		const info = getFrontMatterInfo(content);
+		if (!info.exists) return {};
+		try {
+			const parsed: unknown = parseYaml(info.frontmatter);
+			return isRecord(parsed) ? parsed : {};
+		} catch (error) {
+			console.warn(`Journal View: could not parse properties for ${this.path}`, error);
+			return {};
+		}
+	}
+
+	private frontmatterTags(frontmatter: Record<string, unknown>): string[] {
+		let parsed: string[] | null;
+		try {
+			parsed = parseFrontMatterTags(frontmatter);
+		} catch (error) {
+			console.warn(`Journal View: could not parse tags for ${this.path}`, error);
+			return [];
+		}
+		const tags: string[] = [];
+		const seen = new Set<string>();
+		for (const rawTag of parsed ?? []) {
+			const tag = rawTag.trim().replace(/^#+/, "");
+			const key = tag.toLocaleLowerCase();
+			if (!tag || seen.has(key)) continue;
+			seen.add(key);
+			tags.push(tag);
+		}
+		return tags;
 	}
 
 	private async deleteNote(): Promise<void> {
@@ -490,6 +604,7 @@ export class DaySection {
 		const content = await this.readContent();
 		if (this.destroyed) return;
 		this.lastKnownContent = content;
+		this.refreshMetadata(content);
 		await this.renderPreview(content);
 	}
 
@@ -815,6 +930,10 @@ export class DaySection {
 
 	/** Applies a change that happened outside the journal (sync, another tab). */
 	applyExternalContent(content: string): void {
+		// Frontmatter can safely update while a dirty body waits to save: the body
+		// conflict guard below remains in force, while the read-only strip reflects
+		// the newest complete file immediately.
+		this.refreshMetadata(content);
 		if (!this.editor) {
 			this.lastKnownContent = content;
 			this.externalReloadPending = false;
@@ -849,6 +968,7 @@ export class DaySection {
 	async reload(knownContent?: string): Promise<void> {
 		const content = knownContent ?? (await this.readContent());
 		if (this.destroyed) return;
+		this.refreshMetadata(content);
 		if (this.editor) {
 			this.applyExternalContent(content);
 			return;
@@ -905,6 +1025,7 @@ export class DaySection {
 			this.lastKnownContent = await this.host.app.vault.process(file, (content) =>
 				replaceNoteBody(content, body),
 			);
+			this.refreshMetadata(this.lastKnownContent);
 			return true;
 		} catch (error) {
 			console.error(`Journal View: could not save ${this.path}`, error);

--- a/src/day.ts
+++ b/src/day.ts
@@ -1,9 +1,11 @@
 import {
+	AbstractInputSuggest,
 	App,
 	Component,
 	MarkdownRenderer,
 	Notice,
 	TFile,
+	getAllTags,
 	getFrontMatterInfo,
 	parseFrontMatterTags,
 	parseYaml,
@@ -23,6 +25,63 @@ import { listenForReaderScrollIntent } from "./readerInput";
  * enough to outlast the centring and the rebuild that can follow a go-to.
  */
 const REVEAL_FRAMES = 10;
+
+type PropertyEditKind = "string" | "infer" | "number" | "boolean" | "json";
+
+interface PropertyEditState {
+	property: string;
+	kind: PropertyEditKind;
+	draft: string;
+	invalid: string | null;
+	inputEl: HTMLInputElement | null;
+	wasFocused: boolean;
+	selectionStart: number | null;
+	selectionEnd: number | null;
+}
+
+interface TagEditState {
+	draft: string;
+	invalid: string | null;
+	suggestions: string[];
+	inputEl: HTMLInputElement | null;
+	wasFocused: boolean;
+	selectionStart: number | null;
+	selectionEnd: number | null;
+}
+
+interface ParsedPropertyDraft {
+	valid: boolean;
+	remove: boolean;
+	value?: unknown;
+	error?: string;
+}
+
+/** Autocomplete for the tag input inside a day's metadata strip. */
+class JournalTagSuggest extends AbstractInputSuggest<string> {
+	constructor(
+		app: App,
+		input: HTMLInputElement,
+		private readonly items: () => string[],
+		private readonly onValueSelected: (value: string) => void,
+	) {
+		super(app, input);
+	}
+
+	protected getSuggestions(query: string): string[] {
+		const needle = query.trim().replace(/^#+/, "").toLocaleLowerCase();
+		return this.items().filter((item) => !needle || item.toLocaleLowerCase().includes(needle));
+	}
+
+	renderSuggestion(value: string, el: HTMLElement): void {
+		el.setText(`#${value}`);
+	}
+
+	selectSuggestion(value: string): void {
+		this.setValue(value);
+		this.close();
+		this.onValueSelected(value);
+	}
+}
 
 /** The bits of the journal view a day needs to talk to. */
 export interface DayHost {
@@ -85,6 +144,90 @@ function metadataText(value: unknown): string {
 	return nestedMetadataText(value) || "—";
 }
 
+function propertyEditKind(value: unknown): PropertyEditKind {
+	if (value === null || value === undefined) return "infer";
+	if (typeof value === "boolean") return "boolean";
+	if (typeof value === "number") return "number";
+	if (Array.isArray(value) || isRecord(value)) return "json";
+	return "string";
+}
+
+function propertyDraft(value: unknown, kind: PropertyEditKind): string {
+	if (value === null || value === undefined) return "";
+	if (kind === "json") {
+		try {
+			return JSON.stringify(value) ?? "";
+		} catch {
+			return "";
+		}
+	}
+	if (typeof value === "string") return value;
+	if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+		return String(value);
+	}
+	return nestedMetadataText(value);
+}
+
+const NUMBER_VALUE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i;
+
+function parsePropertyDraft(kind: PropertyEditKind, draft: string): ParsedPropertyDraft {
+	const trimmed = draft.trim();
+	if (!trimmed) return { valid: true, remove: true };
+
+	if (kind === "number") {
+		if (!NUMBER_VALUE.test(trimmed)) {
+			return { valid: false, remove: false, error: "Enter a valid number." };
+		}
+		const value = Number(trimmed);
+		return Number.isFinite(value)
+			? { valid: true, remove: false, value }
+			: { valid: false, remove: false, error: "Enter a finite number." };
+	}
+
+	if (kind === "boolean") {
+		return { valid: true, remove: false, value: trimmed === "true" };
+	}
+
+	if (kind === "json") {
+		try {
+			const value: unknown = JSON.parse(trimmed);
+			if (!Array.isArray(value) && !isRecord(value)) {
+				return { valid: false, remove: false, error: "Enter a JSON array or object." };
+			}
+			return { valid: true, remove: false, value };
+		} catch {
+			return { valid: false, remove: false, error: "Enter valid JSON." };
+		}
+	}
+
+	if (kind === "infer") {
+		if (trimmed === "true" || trimmed === "false") {
+			return { valid: true, remove: false, value: trimmed === "true" };
+		}
+		if (NUMBER_VALUE.test(trimmed)) {
+			const value = Number(trimmed);
+			if (Number.isFinite(value)) return { valid: true, remove: false, value };
+		}
+		if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+			try {
+				const value: unknown = JSON.parse(trimmed);
+				if (Array.isArray(value) || isRecord(value)) {
+					return { valid: true, remove: false, value };
+				}
+			} catch {
+				return { valid: false, remove: false, error: "Enter valid JSON." };
+			}
+		}
+	}
+
+	return { valid: true, remove: false, value: draft };
+}
+
+function normalizedTag(raw: string): string | null {
+	const tag = raw.trim().replace(/^#+/, "");
+	return tag && !/[\s,]/.test(tag) ? tag : null;
+}
+
 function sameFindRange(left: FindRange | null, right: FindRange | null): boolean {
 	return left === right || (!!left && !!right && left.from === right.from && left.to === right.to);
 }
@@ -144,6 +287,14 @@ export class DaySection {
 	private lastKnownContent = "";
 	/** Newest complete file content, including external frontmatter held off from a dirty editor. */
 	private latestContent = "";
+	private propertyEdit: PropertyEditState | null = null;
+	private tagEdit: TagEditState | null = null;
+	private tagSuggest: JournalTagSuggest | null = null;
+	private refreshingMetadata = false;
+	private tagBlurTimer = 0;
+	private metadataWrites: Promise<void> = Promise.resolve();
+	private pendingProperties = new Set<string>();
+	private tagsPending = false;
 	/** An external write held off until this day's own pending edit has settled. */
 	private externalReloadPending = false;
 	/** Template text shown in an empty day but not yet accepted by the reader. */
@@ -408,43 +559,436 @@ export class DaySection {
 		this.refreshMetadata();
 	}
 
-	/** Rebuilds the read-only strip from the latest complete note content. */
+	/** Rebuilds the editable strip from the latest complete note content. */
 	refreshMetadata(content = this.latestContent): void {
 		if (this.destroyed) return;
 		this.latestContent = content;
+		this.captureMetadataEdit();
+		window.clearTimeout(this.tagBlurTimer);
+		this.tagBlurTimer = 0;
+		this.refreshingMetadata = true;
+		this.tagSuggest?.close();
+		this.tagSuggest = null;
 		this.metadataEl.empty();
 		this.metadataEl.hidden = true;
-		const { displayProperties, showTags } = this.host.plugin.settings;
-		if (!this.file || (!displayProperties.length && !showTags)) return;
 
-		const frontmatter = this.parseFrontmatter(content);
-		const entries = Object.entries(frontmatter);
-		for (const property of displayProperties) {
-			const key = property.toLocaleLowerCase();
-			const entry = entries.find(([name]) => name.toLocaleLowerCase() === key);
-			const row = this.metadataEl.createDiv({ cls: "journal-day-metadata-row" });
-			row.createSpan({ cls: "journal-day-metadata-label", text: property });
-			row.createSpan({ cls: "journal-day-metadata-value", text: metadataText(entry?.[1]) });
+		try {
+			const { displayProperties, showTags } = this.host.plugin.settings;
+			if (!this.file || (!displayProperties.length && !showTags)) {
+				this.propertyEdit = null;
+				this.tagEdit = null;
+				return;
+			}
+
+			const displayed = new Set(displayProperties.map((property) => property.toLocaleLowerCase()));
+			if (this.propertyEdit && !displayed.has(this.propertyEdit.property.toLocaleLowerCase())) {
+				this.propertyEdit = null;
+			}
+			if (!showTags) this.tagEdit = null;
+
+			const frontmatter = this.parseFrontmatter(content);
+			const entries = Object.entries(frontmatter);
+			for (const property of displayProperties) {
+				const key = property.toLocaleLowerCase();
+				const entry = entries.find(([name]) => name.toLocaleLowerCase() === key);
+				const row = this.metadataEl.createDiv({ cls: "journal-day-metadata-row" });
+				row.createSpan({ cls: "journal-day-metadata-label", text: property });
+				const pending = this.pendingProperties.has(key);
+				row.toggleClass("journal-day-metadata-pending", pending);
+				if (pending) row.setAttribute("aria-busy", "true");
+
+				if (this.propertyEdit?.property.toLocaleLowerCase() === key) {
+					this.renderPropertyEditor(row, this.propertyEdit);
+				} else {
+					const value = row.createEl("button", {
+						cls: "journal-day-metadata-value journal-day-metadata-value-button",
+						text: metadataText(entry?.[1]),
+						attr: { type: "button", "aria-label": `Edit ${property}` },
+					});
+					value.disabled = pending;
+					value.addEventListener("click", (event) => {
+						event.stopPropagation();
+						this.startPropertyEdit(property, entry?.[1]);
+					});
+				}
+			}
+
+			if (showTags) this.renderTags(frontmatter);
+			this.metadataEl.hidden = this.metadataEl.childElementCount === 0;
+		} finally {
+			this.refreshingMetadata = false;
+			this.restoreMetadataFocus();
 		}
+	}
 
-		if (showTags) {
-			const tags = this.frontmatterTags(frontmatter);
-			if (tags.length) {
-				const row = this.metadataEl.createDiv({
-					cls: "journal-day-metadata-row journal-day-metadata-tags",
-				});
-				const label = row.createSpan({
-					cls: "journal-day-metadata-label journal-day-metadata-tags-label",
-				});
-				setIcon(label, "tag");
-				label.querySelector("svg")?.setAttribute("aria-hidden", "true");
-				setTooltip(label, "Tags");
-				const list = row.createDiv({ cls: "journal-day-tags" });
-				for (const tag of tags) list.createSpan({ cls: "journal-day-tag", text: `#${tag}` });
+	private captureMetadataEdit(): void {
+		const active = this.metadataEl.ownerDocument.activeElement;
+		for (const state of [this.propertyEdit, this.tagEdit]) {
+			const input = state?.inputEl;
+			if (!state || !input) continue;
+			if (input.type === "checkbox") state.draft = String(input.checked);
+			else state.draft = input.value;
+			if (active === input) {
+				state.wasFocused = true;
+				state.selectionStart = input.selectionStart;
+				state.selectionEnd = input.selectionEnd;
 			}
 		}
+	}
 
-		this.metadataEl.hidden = this.metadataEl.childElementCount === 0;
+	private restoreMetadataFocus(): void {
+		for (const state of [this.propertyEdit, this.tagEdit]) {
+			if (!state?.wasFocused || !state.inputEl) continue;
+			const input = state.inputEl;
+			window.requestAnimationFrame(() => {
+				if (this.destroyed || !input.isConnected || state.inputEl !== input) return;
+				input.focus();
+				if (input.type !== "checkbox" && state.selectionStart !== null && state.selectionEnd !== null) {
+					input.setSelectionRange(state.selectionStart, state.selectionEnd);
+				}
+				if (state === this.tagEdit) this.tagSuggest?.open();
+				state.wasFocused = false;
+			});
+		}
+	}
+
+	private startPropertyEdit(property: string, value: unknown): void {
+		if (!this.file || this.pendingProperties.has(property.toLocaleLowerCase())) return;
+		if (this.propertyEdit) {
+			this.commitPropertyEdit(this.propertyEdit);
+			if (this.propertyEdit) return; // invalid input stays open until corrected or cancelled
+		}
+		window.clearTimeout(this.tagBlurTimer);
+		this.tagBlurTimer = 0;
+		this.tagSuggest?.close();
+		this.tagSuggest = null;
+		this.tagEdit = null;
+		const kind = propertyEditKind(value);
+		this.propertyEdit = {
+			property,
+			kind,
+			draft: propertyDraft(value, kind),
+			invalid: null,
+			inputEl: null,
+			wasFocused: true,
+			selectionStart: null,
+			selectionEnd: null,
+		};
+		this.refreshMetadata();
+	}
+
+	private renderPropertyEditor(row: HTMLElement, state: PropertyEditState): void {
+		const editor = row.createSpan({ cls: "journal-day-property-editor" });
+		const input = editor.createEl("input", {
+			cls: "journal-day-property-input",
+			attr: {
+				type: state.kind === "number" ? "number" : state.kind === "boolean" ? "checkbox" : "text",
+				"aria-label": `Edit ${state.property}`,
+			},
+		});
+		state.inputEl = input;
+		if (state.kind === "boolean") input.checked = state.draft === "true";
+		else input.value = state.draft;
+		this.syncInvalidMetadataInput(input, state.invalid);
+
+		input.addEventListener("input", () => {
+			state.draft = input.type === "checkbox" ? String(input.checked) : input.value;
+			state.invalid = null;
+			this.syncInvalidMetadataInput(input, null);
+		});
+		input.addEventListener("keydown", (event) => {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				this.cancelPropertyEdit(state);
+			} else if (event.key === "Enter" && state.kind !== "boolean") {
+				event.preventDefault();
+				this.commitPropertyEdit(state);
+			}
+		});
+		if (state.kind === "boolean") {
+			input.addEventListener("change", () => {
+				state.draft = String(input.checked);
+				this.commitPropertyEdit(state);
+			});
+		} else {
+			input.addEventListener("blur", (event) => {
+				const related = event.relatedTarget as Node | null;
+				if (this.refreshingMetadata || editor.contains(related)) return;
+				window.setTimeout(() => {
+					if (this.propertyEdit === state && !this.refreshingMetadata) this.commitPropertyEdit(state);
+				}, 0);
+			});
+		}
+
+		const clear = editor.createEl("button", {
+			cls: "clickable-icon journal-day-metadata-clear",
+			attr: { type: "button", "aria-label": `Clear ${state.property}` },
+		});
+		setIcon(clear, "x");
+		setTooltip(clear, `Clear ${state.property}`);
+		clear.addEventListener("pointerdown", (event) => event.preventDefault());
+		clear.addEventListener("click", (event) => {
+			event.stopPropagation();
+			this.commitPropertyEdit(state, true);
+		});
+	}
+
+	private syncInvalidMetadataInput(input: HTMLInputElement, error: string | null): void {
+		input.toggleClass("is-invalid", !!error);
+		input.setAttribute("aria-invalid", error ? "true" : "false");
+		if (error) input.setAttribute("title", error);
+		else input.removeAttribute("title");
+	}
+
+	private cancelPropertyEdit(state: PropertyEditState): void {
+		if (this.propertyEdit !== state) return;
+		this.propertyEdit = null;
+		this.refreshMetadata();
+	}
+
+	private commitPropertyEdit(state: PropertyEditState, forceRemove = false): void {
+		if (this.propertyEdit !== state) return;
+		const parsed = forceRemove
+			? { valid: true, remove: true }
+			: parsePropertyDraft(state.kind, state.inputEl?.type === "checkbox" ? String(state.inputEl.checked) : state.draft);
+		if (!parsed.valid) {
+			state.invalid = parsed.error ?? "Enter a valid value.";
+			if (state.inputEl) this.syncInvalidMetadataInput(state.inputEl, state.invalid);
+			return;
+		}
+
+		this.propertyEdit = null;
+		const pendingKey = state.property.toLocaleLowerCase();
+		this.pendingProperties.add(pendingKey);
+		this.refreshMetadata();
+		void this.writeProperty(state.property, parsed.remove, parsed.value).finally(() => {
+			this.pendingProperties.delete(pendingKey);
+			if (!this.destroyed) this.refreshMetadata();
+		});
+	}
+
+	private renderTags(frontmatter: Record<string, unknown>): void {
+		const tags = this.frontmatterTags(frontmatter);
+		const row = this.metadataEl.createDiv({
+			cls: "journal-day-metadata-row journal-day-metadata-tags",
+		});
+		row.toggleClass("journal-day-metadata-pending", this.tagsPending);
+		if (this.tagsPending) row.setAttribute("aria-busy", "true");
+		const label = row.createSpan({
+			cls: "journal-day-metadata-label journal-day-metadata-tags-label",
+		});
+		setIcon(label, "tag");
+		label.querySelector("svg")?.setAttribute("aria-hidden", "true");
+		setTooltip(label, "Tags");
+		const list = row.createDiv({ cls: "journal-day-tags" });
+
+		for (const tag of tags) {
+			const chip = list.createEl("button", {
+				cls: "journal-day-tag journal-day-tag-remove",
+				attr: { type: "button", "aria-label": `Remove tag ${tag}` },
+			});
+			chip.createSpan({ text: `#${tag}` });
+			chip.createSpan({ cls: "journal-day-tag-x", text: "×", attr: { "aria-hidden": "true" } });
+			chip.disabled = this.tagsPending;
+			chip.addEventListener("click", (event) => {
+				event.stopPropagation();
+				this.removeTag(tag);
+			});
+		}
+
+		if (this.tagEdit) this.renderTagEditor(list, this.tagEdit, tags);
+		else {
+			const add = list.createEl("button", {
+				cls: "clickable-icon journal-day-tag-add",
+				attr: { type: "button", "aria-label": "Add tag", "aria-haspopup": "listbox" },
+			});
+			setIcon(add, "plus");
+			setTooltip(add, "Add tag");
+			add.disabled = this.tagsPending;
+			add.addEventListener("click", (event) => {
+				event.stopPropagation();
+				this.startTagEdit(tags);
+			});
+		}
+	}
+
+	private startTagEdit(currentTags: string[]): void {
+		if (!this.file || this.tagsPending) return;
+		if (this.propertyEdit) {
+			this.commitPropertyEdit(this.propertyEdit);
+			if (this.propertyEdit) return;
+		}
+		this.tagEdit = {
+			draft: "",
+			invalid: null,
+			suggestions: this.availableVaultTags(currentTags),
+			inputEl: null,
+			wasFocused: true,
+			selectionStart: 0,
+			selectionEnd: 0,
+		};
+		this.refreshMetadata();
+	}
+
+	private renderTagEditor(list: HTMLElement, state: TagEditState, currentTags: string[]): void {
+		const input = list.createEl("input", {
+			cls: "journal-day-tag-input",
+			attr: { type: "text", placeholder: "Add tag", "aria-label": "Add tag" },
+		});
+		input.value = state.draft;
+		state.inputEl = input;
+		this.syncInvalidMetadataInput(input, state.invalid);
+		this.tagSuggest = new JournalTagSuggest(
+			this.host.app,
+			input,
+			() => state.suggestions,
+			(value) => {
+				window.clearTimeout(this.tagBlurTimer);
+				this.tagBlurTimer = 0;
+				this.commitTag(state, value, currentTags);
+			},
+		);
+		input.addEventListener("input", () => {
+			state.draft = input.value;
+			state.invalid = null;
+			this.syncInvalidMetadataInput(input, null);
+		});
+		input.addEventListener("keydown", (event) => {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				this.cancelTagEdit(state);
+			} else if (event.key === "Enter" || event.key === ",") {
+				event.preventDefault();
+				this.commitTag(state, input.value, currentTags);
+			}
+		});
+		input.addEventListener("blur", () => {
+			if (this.refreshingMetadata) return;
+			window.clearTimeout(this.tagBlurTimer);
+			this.tagBlurTimer = window.setTimeout(() => {
+				this.tagBlurTimer = 0;
+				if (this.tagEdit === state && state.inputEl === input && input.ownerDocument.activeElement !== input) {
+					this.cancelTagEdit(state);
+				}
+			}, 150);
+		});
+	}
+
+	private cancelTagEdit(state: TagEditState): void {
+		if (this.tagEdit !== state) return;
+		window.clearTimeout(this.tagBlurTimer);
+		this.tagBlurTimer = 0;
+		this.tagSuggest?.close();
+		this.tagSuggest = null;
+		this.tagEdit = null;
+		this.refreshMetadata();
+	}
+
+	private commitTag(state: TagEditState, raw: string, currentTags: string[]): void {
+		if (this.tagEdit !== state) return;
+		const tag = normalizedTag(raw);
+		if (!tag) {
+			state.invalid = "Tags cannot be empty or contain spaces or commas.";
+			if (state.inputEl) this.syncInvalidMetadataInput(state.inputEl, state.invalid);
+			return;
+		}
+		if (currentTags.some((current) => current.toLocaleLowerCase() === tag.toLocaleLowerCase())) {
+			state.invalid = `#${tag} is already present.`;
+			if (state.inputEl) this.syncInvalidMetadataInput(state.inputEl, state.invalid);
+			return;
+		}
+
+		window.clearTimeout(this.tagBlurTimer);
+		this.tagBlurTimer = 0;
+		this.tagSuggest?.close();
+		this.tagSuggest = null;
+		this.tagEdit = null;
+		this.tagsPending = true;
+		this.refreshMetadata();
+		void this.writeTag("add", tag).finally(() => {
+			this.tagsPending = false;
+			if (!this.destroyed) this.refreshMetadata();
+		});
+	}
+
+	private removeTag(tag: string): void {
+		if (this.tagsPending) return;
+		this.tagsPending = true;
+		this.refreshMetadata();
+		void this.writeTag("remove", tag).finally(() => {
+			this.tagsPending = false;
+			if (!this.destroyed) this.refreshMetadata();
+		});
+	}
+
+	private availableVaultTags(currentTags: string[]): string[] {
+		const selected = new Set(currentTags.map((tag) => tag.toLocaleLowerCase()));
+		const available = new Map<string, string>();
+		for (const file of this.host.app.vault.getMarkdownFiles()) {
+			const cache = this.host.app.metadataCache.getFileCache(file);
+			if (!cache) continue;
+			for (const rawTag of getAllTags(cache) ?? []) {
+				const tag = normalizedTag(rawTag);
+				const key = tag?.toLocaleLowerCase();
+				if (!tag || !key || selected.has(key) || available.has(key)) continue;
+				available.set(key, tag);
+			}
+		}
+		return Array.from(available.values()).sort((left, right) => left.localeCompare(right));
+	}
+
+	private writeProperty(property: string, remove: boolean, value: unknown): Promise<void> {
+		return this.enqueueMetadataWrite(`update ${property}`, (frontmatter) => {
+			const actual = Object.keys(frontmatter).find(
+				(key) => key.toLocaleLowerCase() === property.toLocaleLowerCase(),
+			);
+			if (remove) {
+				if (actual) delete frontmatter[actual];
+			} else {
+				frontmatter[actual ?? property] = value;
+			}
+		});
+	}
+
+	private writeTag(action: "add" | "remove", tag: string): Promise<void> {
+		return this.enqueueMetadataWrite(`${action} tag ${tag}`, (frontmatter) => {
+			const actual = Object.keys(frontmatter).find((key) => key.toLocaleLowerCase() === "tags");
+			const tags = this.frontmatterTags(frontmatter);
+			const target = tag.toLocaleLowerCase();
+			const next =
+				action === "add"
+					? tags.some((current) => current.toLocaleLowerCase() === target)
+						? tags
+						: [...tags, tag]
+					: tags.filter((current) => current.toLocaleLowerCase() !== target);
+			if (next.length) frontmatter[actual ?? "tags"] = next;
+			else if (actual) delete frontmatter[actual];
+		});
+	}
+
+	private enqueueMetadataWrite(
+		description: string,
+		mutate: (frontmatter: Record<string, unknown>) => void,
+	): Promise<void> {
+		const file = this.file;
+		if (!file) return Promise.resolve();
+		const operation = this.metadataWrites.then(async () => {
+			await this.host.app.fileManager.processFrontMatter(file, mutate);
+			const content = await this.host.app.vault.read(file);
+			if (!this.destroyed && this.file === file) this.applyExternalContent(content);
+		});
+		const handled = operation.catch(async (error: unknown) => {
+			console.error(`Journal View: could not ${description} in ${file.path}`, error);
+			new Notice(`Journal View: could not ${description}`);
+			if (this.destroyed || this.file !== file) return;
+			try {
+				this.applyExternalContent(await this.host.app.vault.read(file));
+			} catch {
+				// The original error is the useful one; a failed recovery read adds nothing.
+			}
+		});
+		this.metadataWrites = handled;
+		return handled;
 	}
 
 	private parseFrontmatter(content: string): Record<string, unknown> {
@@ -462,7 +1006,8 @@ export class DaySection {
 	private frontmatterTags(frontmatter: Record<string, unknown>): string[] {
 		let parsed: string[] | null;
 		try {
-			parsed = parseFrontMatterTags(frontmatter);
+			const key = Object.keys(frontmatter).find((name) => name.toLocaleLowerCase() === "tags");
+			parsed = key ? parseFrontMatterTags({ tags: frontmatter[key] }) : [];
 		} catch (error) {
 			console.warn(`Journal View: could not parse tags for ${this.path}`, error);
 			return [];
@@ -480,7 +1025,7 @@ export class DaySection {
 	}
 
 	private async deleteNote(): Promise<void> {
-		await this.flush();
+		await this.flush(true);
 		if (this.queue.hasPending) return; // the failed save already showed a notice
 
 		const file = this.file;
@@ -524,7 +1069,8 @@ export class DaySection {
 	/* -------------------------------------------------------------- preview */
 
 	get hasFocus(): boolean {
-		return this.focused || (this.editor?.hasFocus() ?? false);
+		const active = this.metadataEl.ownerDocument.activeElement;
+		return this.focused || (this.editor?.hasFocus() ?? false) || (!!active && this.metadataEl.contains(active));
 	}
 
 	get isDirty(): boolean {
@@ -931,7 +1477,7 @@ export class DaySection {
 	/** Applies a change that happened outside the journal (sync, another tab). */
 	applyExternalContent(content: string): void {
 		// Frontmatter can safely update while a dirty body waits to save: the body
-		// conflict guard below remains in force, while the read-only strip reflects
+		// conflict guard below remains in force, while the metadata strip reflects
 		// the newest complete file immediately.
 		this.refreshMetadata(content);
 		if (!this.editor) {
@@ -998,10 +1544,11 @@ export class DaySection {
 		if (body !== editorBody(this.lastKnownContent)) void this.queue.submit(body);
 	}
 
-	async flush(): Promise<void> {
+	async flush(commitMetadataDraft = false): Promise<void> {
 		window.clearTimeout(this.saveTimer);
+		if (commitMetadataDraft && this.propertyEdit) this.commitPropertyEdit(this.propertyEdit);
 		this.capture();
-		await this.queue.settled();
+		await Promise.all([this.queue.settled(), this.metadataWrites]);
 		if (!this.destroyed && this.externalReloadPending && !this.isDirty) await this.reload();
 	}
 
@@ -1065,6 +1612,12 @@ export class DaySection {
 		this.destroyed = true;
 		this.focusSettleToken++;
 		window.clearTimeout(this.saveTimer);
+		window.clearTimeout(this.tagBlurTimer);
+		this.tagBlurTimer = 0;
+		this.tagSuggest?.close();
+		this.tagSuggest = null;
+		this.propertyEdit = null;
+		this.tagEdit = null;
 		this.stopRevealing();
 		// Anything unsaved goes to the queue, which outlives this object.
 		this.capture();

--- a/src/day.ts
+++ b/src/day.ts
@@ -678,6 +678,7 @@ export class DaySection {
 	}
 
 	private renderPropertyEditor(row: HTMLElement, state: PropertyEditState): void {
+		row.addClass("journal-day-metadata-editing");
 		const editor = row.createSpan({ cls: "journal-day-property-editor" });
 		const input = editor.createEl("input", {
 			cls: "journal-day-property-input",

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,15 +24,22 @@ export default class JournalViewPlugin extends Plugin {
 	private initialDates = new Map<WorkspaceLeaf, Moment>();
 
 	private notifyViews = debounce(
-		() => {
-			for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE_JOURNAL)) {
-				const view = leaf.view;
-				if (view instanceof JournalView) void view.onSettingsChanged();
-			}
-		},
+		() => this.updateViews(),
 		400,
 		true,
 	);
+
+	private updateViews(): void {
+		for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE_JOURNAL)) {
+			const view = leaf.view;
+			if (view instanceof JournalView) void view.onSettingsChanged();
+		}
+	}
+
+	/** Applies modal controls live without the settings tab's typing debounce. */
+	notifyViewsImmediately(): void {
+		this.updateViews();
+	}
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
@@ -187,7 +194,7 @@ export default class JournalViewPlugin extends Plugin {
 	async loadSettings(): Promise<void> {
 		const saved: unknown = await this.loadData();
 		if (!isRecord(saved)) {
-			this.settings = { ...DEFAULT_SETTINGS };
+			this.settings = { ...DEFAULT_SETTINGS, displayProperties: [] };
 			return;
 		}
 		this.settings = {
@@ -208,14 +215,16 @@ export default class JournalViewPlugin extends Plugin {
 			richEditor: booleanSetting(saved.richEditor, DEFAULT_SETTINGS.richEditor),
 			focusTodayOnOpen: booleanSetting(saved.focusTodayOnOpen, DEFAULT_SETTINGS.focusTodayOnOpen),
 			hideEmptyDays: booleanSetting(saved.hideEmptyDays, DEFAULT_SETTINGS.hideEmptyDays),
+			showTags: booleanSetting(saved.showTags, DEFAULT_SETTINGS.showTags),
+			displayProperties: propertyNamesSetting(saved.displayProperties),
 			daySortDirection: daySortDirectionSetting(saved.daySortDirection),
 		};
 	}
 
-	async saveSettings(): Promise<void> {
+	async saveSettings(scheduleViewUpdate = true): Promise<void> {
 		await this.saveData(this.settings);
 		this.syncDailyNoteActions();
-		this.notifyViews();
+		if (scheduleViewUpdate) this.notifyViews();
 	}
 }
 
@@ -248,6 +257,21 @@ function loadedDaysSetting(value: unknown): number {
 
 function booleanSetting(value: unknown, fallback: boolean): boolean {
 	return typeof value === "boolean" ? value : fallback;
+}
+
+function propertyNamesSetting(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const names: string[] = [];
+	const seen = new Set<string>();
+	for (const item of value) {
+		if (typeof item !== "string") continue;
+		const name = item.trim();
+		const key = name.toLocaleLowerCase();
+		if (!name || key === "tags" || seen.has(key)) continue;
+		seen.add(key);
+		names.push(name);
+	}
+	return names;
 }
 
 function daySortDirectionSetting(value: unknown): DaySortDirection {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -36,6 +36,10 @@ export interface JournalViewSettings {
 	focusTodayOnOpen: boolean;
 	/** Show only days that have a note (today always shows). */
 	hideEmptyDays: boolean;
+	/** Show frontmatter tags above each existing note's body. */
+	showTags: boolean;
+	/** Frontmatter property names shown above each existing note's body. */
+	displayProperties: string[];
 	/** Chronological direction in which days are laid out. */
 	daySortDirection: DaySortDirection;
 }
@@ -54,6 +58,8 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	richEditor: true,
 	focusTodayOnOpen: true,
 	hideEmptyDays: true,
+	showTags: false,
+	displayProperties: [],
 	daySortDirection: "ascending",
 };
 

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -41,12 +41,6 @@ export class JournalToolbar {
 			this.labelEl = toolbar.createDiv({ cls: "journal-toolbar-label", text: "Journal" });
 			const buttons = toolbar.createDiv({ cls: "journal-toolbar-actions" });
 
-			this.filterButton = buttons.createEl("button", {
-				cls: "clickable-icon journal-toolbar-button",
-			});
-			this.filterButton.addEventListener("click", () => actions.onToggleFilter());
-			this.buttons.push(this.filterButton);
-
 			const appearanceButton = buttons.createEl("button", {
 				cls: "clickable-icon journal-toolbar-button",
 				attr: { "aria-haspopup": "dialog" },
@@ -55,6 +49,12 @@ export class JournalToolbar {
 			setTooltip(appearanceButton, "Customization");
 			appearanceButton.addEventListener("click", () => actions.onShowAppearance());
 			this.buttons.push(appearanceButton);
+
+			this.filterButton = buttons.createEl("button", {
+				cls: "clickable-icon journal-toolbar-button",
+			});
+			this.filterButton.addEventListener("click", () => actions.onToggleFilter());
+			this.buttons.push(this.filterButton);
 
 			const findButton = buttons.createEl("button", {
 				cls: "clickable-icon journal-toolbar-button",
@@ -115,8 +115,8 @@ export class JournalToolbar {
 		// controls rather than the date destinations on the right. Appearance is
 		// the adjacent description of what each shown day contains.
 		const left = view.containerEl.querySelector(".view-header-left");
-		left?.append(this.filterButton, appearanceButton);
-		this.buttons.push(this.filterButton, appearanceButton);
+		left?.append(appearanceButton, this.filterButton);
+		this.buttons.push(appearanceButton, this.filterButton);
 	}
 
 	setLabel(text: string): void {

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -16,6 +16,7 @@ function applyIcon(el: HTMLElement, ...names: string[]): void {
 /** What the toolbar's controls ask the view to do. */
 export interface ToolbarActions {
 	onToggleFilter(): void;
+	onShowAppearance(): void;
 	onShowFind(): void;
 	onGoToDate(): void;
 	onGoToToday(): void;
@@ -45,6 +46,15 @@ export class JournalToolbar {
 			});
 			this.filterButton.addEventListener("click", () => actions.onToggleFilter());
 			this.buttons.push(this.filterButton);
+
+			const appearanceButton = buttons.createEl("button", {
+				cls: "clickable-icon journal-toolbar-button",
+				attr: { "aria-haspopup": "dialog" },
+			});
+			applyIcon(appearanceButton, "settings-2", "settings");
+			setTooltip(appearanceButton, "Customization");
+			appearanceButton.addEventListener("click", () => actions.onShowAppearance());
+			this.buttons.push(appearanceButton);
 
 			const findButton = buttons.createEl("button", {
 				cls: "clickable-icon journal-toolbar-button",
@@ -96,10 +106,17 @@ export class JournalToolbar {
 
 		this.filterButton = view.addAction("filter", "Filter days", () => actions.onToggleFilter());
 		this.filterButton.addClass("journal-toolbar-button");
+		const appearanceButton = view.addAction("settings-2", "Customization", () => actions.onShowAppearance());
+		appearanceButton.addClass("journal-toolbar-button");
+		applyIcon(appearanceButton, "settings-2", "settings");
+		setTooltip(appearanceButton, "Customization");
+		appearanceButton.setAttribute("aria-haspopup", "dialog");
 		// Filter describes what the journal shows, so keep it with the navigation
-		// controls rather than the date destinations on the right.
-		view.containerEl.querySelector(".view-header-left")?.appendChild(this.filterButton);
-		this.buttons.push(this.filterButton);
+		// controls rather than the date destinations on the right. Appearance is
+		// the adjacent description of what each shown day contains.
+		const left = view.containerEl.querySelector(".view-header-left");
+		left?.append(this.filterButton, appearanceButton);
+		this.buttons.push(this.filterButton, appearanceButton);
 	}
 
 	setLabel(text: string): void {

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,6 +1,7 @@
 import { ItemView, Scope, TAbstractFile, TFile, WorkspaceLeaf } from "obsidian";
 import type JournalViewPlugin from "./main";
 import { AnchorHost, START_GUTTER, ScrollAnchor } from "./anchor";
+import { AppearanceModal } from "./appearance";
 import { DatePickerModal } from "./datePicker";
 import { DayHost, DaySection } from "./day";
 import { DayWalker, isOffsetReachable } from "./dayWalk";
@@ -62,6 +63,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private find?: JournalFind;
 	/** The open date picker, which has to go when the view does. */
 	private picker: DatePickerModal | null = null;
+	/** Appearance settings owned by this view while its modal is open. */
+	private appearance: AppearanceModal | null = null;
 	private readonly anchoring = new ScrollAnchor(this);
 	private readonly editors = new EditorWindow(this);
 	private walker!: DayWalker;
@@ -164,6 +167,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 		this.toolbar = new JournalToolbar(this, {
 			onToggleFilter: () => void this.toggleHideEmptyDays(),
+			onShowAppearance: () => this.openAppearance(),
 			onShowFind: () => this.showFind(),
 			onGoToDate: () => this.openDatePicker(),
 			onGoToToday: () => this.goToToday(true),
@@ -190,9 +194,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	async onClose(): Promise<void> {
-		// The picker holds this view in its callback, so a leaf that closes
-		// while it is open would leave it able to navigate a dead journal.
+		// Modals hold this view in their callbacks, so they have to go with it.
 		this.picker?.close();
+		this.appearance?.close();
 		this.find?.destroy();
 		this.find = undefined;
 		this.toolbar?.destroy();
@@ -950,6 +954,18 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		picker.open();
 	}
 
+	/** Opens the global metadata display controls. */
+	private openAppearance(): void {
+		this.appearance?.close();
+		const appearance = new AppearanceModal(this.app, this.plugin, {
+			onDismiss: () => {
+				if (this.appearance === appearance) this.appearance = null;
+			},
+		});
+		this.appearance = appearance;
+		appearance.open();
+	}
+
 	/**
 	 * Moves the journal to `date`. A day already in the window is scrolled to;
 	 * anything further away is a rebuild around that day. A day with no note is
@@ -1232,6 +1248,10 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			this.settingsPending = true;
 			return;
 		}
+		// Appearance settings do not change the editor or the day window. Repaint
+		// their small read-only strips in place and let the resize anchor absorb
+		// any height change without moving the reader.
+		for (const section of this.sections) section.refreshMetadata();
 		const signature = this.rebuildSettingsSignature();
 		if (signature === this.appliedSettingsSignature) {
 			const previousMax = this.appliedMaxLoadedDays;

--- a/src/view.ts
+++ b/src/view.ts
@@ -228,7 +228,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	async flushAll(): Promise<void> {
-		await Promise.all(this.sections.map((section) => section.flush()));
+		await Promise.all(this.sections.map((section) => section.flush(true)));
 	}
 
 	/* --------------------------------------------------------------- build */
@@ -1249,7 +1249,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			return;
 		}
 		// Appearance settings do not change the editor or the day window. Repaint
-		// their small read-only strips in place and let the resize anchor absorb
+		// their small metadata strips in place and let the resize anchor absorb
 		// any height change without moving the reader.
 		for (const section of this.sections) section.refreshMetadata();
 		const signature = this.rebuildSettingsSignature();

--- a/styles.css
+++ b/styles.css
@@ -403,6 +403,10 @@ button.journal-day-create:hover {
 	padding-block: var(--size-2-2);
 }
 
+.journal-day-metadata-row:not(.journal-day-metadata-tags).journal-day-metadata-list {
+	padding-block: var(--size-2-2);
+}
+
 .journal-day-metadata-label {
 	color: var(--text-muted);
 	font-weight: var(--font-medium);
@@ -454,6 +458,14 @@ button.journal-day-metadata-value-button:focus-visible,
 	max-width: 100%;
 }
 
+.journal-day-property-list {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--size-2-1);
+	min-width: 0;
+}
+
 .journal-day-property-input,
 .journal-day-tag-input {
 	height: 22px;
@@ -465,7 +477,10 @@ button.journal-day-metadata-value-button:focus-visible,
 }
 
 .journal-day-property-input:not([type="checkbox"]) {
-	width: min(14rem, 38vw);
+	width: var(--journal-property-input-width, min(9rem, 34vw));
+	min-width: min(9rem, 34vw);
+	max-width: min(24rem, 55vw);
+	box-sizing: border-box;
 }
 
 .journal-day-metadata-row.journal-day-metadata-editing .journal-day-property-input {
@@ -598,7 +613,8 @@ button.journal-day-metadata-value-button:focus-visible,
 	box-sizing: border-box;
 }
 
-.journal-day-metadata-row.journal-day-metadata-tags .journal-day-tag-input {
+.journal-day-metadata-row.journal-day-metadata-tags .journal-day-tag-input,
+.journal-day-metadata-row.journal-day-metadata-list .journal-day-property-list-input {
 	width: min(9rem, 34vw);
 	height: 20px;
 	min-height: 20px;

--- a/styles.css
+++ b/styles.css
@@ -361,6 +361,83 @@ button.journal-day-create:hover {
 	color: var(--text-normal);
 }
 
+/* ----------------------------------------------------------- metadata --- */
+
+.journal-day-metadata {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	column-gap: var(--size-2-3);
+	row-gap: var(--size-2-2);
+	/* Match the header's bottom margin so the strip has the same breathing
+	   room above and below it. */
+	margin: 0 0 var(--size-2-3);
+	font-size: var(--font-ui-smaller);
+	line-height: var(--line-height-tight);
+}
+
+.journal-day-metadata[hidden] {
+	display: none;
+}
+
+.journal-day-metadata-row {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--size-2-3);
+	width: max-content;
+	max-width: 100%;
+	min-width: 0;
+	padding: var(--size-2-2) var(--size-2-3);
+	border-radius: var(--radius-s);
+	background-color: var(--background-primary-alt);
+	box-sizing: border-box;
+	flex: 0 0 auto;
+}
+
+.journal-day-metadata-label {
+	color: var(--text-muted);
+	font-weight: var(--font-medium);
+	white-space: nowrap;
+	flex: 0 0 auto;
+}
+
+.journal-day-metadata-value {
+	min-width: 0;
+	color: var(--text-normal);
+	overflow-wrap: anywhere;
+}
+
+.journal-day-metadata-tags {
+	align-items: center;
+}
+
+.journal-day-metadata-tags-label {
+	display: flex;
+	align-items: center;
+	color: var(--text-muted);
+}
+
+.journal-day-metadata-tags-label svg {
+	width: var(--icon-xs);
+	height: var(--icon-xs);
+}
+
+.journal-day-tags {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--size-2-1);
+	min-width: 0;
+}
+
+.journal-day-tag {
+	padding: 1px var(--size-2-2);
+	border-radius: var(--radius-s);
+	background-color: var(--background-modifier-hover);
+	color: var(--text-accent);
+	overflow-wrap: anywhere;
+}
+
 .journal-day-body {
 	/* Breathing room above and below the text; zero for an ordinary day. */
 	--journal-body-pad-top: 0px;
@@ -717,6 +794,38 @@ button.journal-picker-day.is-out-of-range:hover {
 
 .journal-picker-blank {
 	height: 34px;
+}
+
+/* ----------------------------------------------------- appearance modal -- */
+
+.journal-appearance-modal {
+	width: min(520px, 92vw);
+}
+
+.journal-appearance-modal .modal-content {
+	margin-top: var(--size-4-2);
+}
+
+.journal-appearance-modal input[type="text"] {
+	width: min(16rem, 45vw);
+}
+
+.modal.journal-appearance-modal .modal-content .journal-appearance-add-property.setting-item {
+	border-top: 0;
+}
+
+.journal-appearance-properties {
+	max-height: min(40vh, 320px);
+	overflow-y: auto;
+	overscroll-behavior: contain;
+}
+
+.journal-appearance-properties > .setting-item:first-child {
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.journal-appearance-empty {
+	padding: var(--size-4-3) 0;
 }
 
 /* -------------------------------------------------------------- settings -- */

--- a/styles.css
+++ b/styles.css
@@ -387,11 +387,20 @@ button.journal-day-create:hover {
 	width: max-content;
 	max-width: 100%;
 	min-width: 0;
+	min-height: calc(20px + 2 * var(--size-2-2));
 	padding: var(--size-2-2) var(--size-2-3);
 	border-radius: var(--radius-s);
 	background-color: var(--background-primary-alt);
 	box-sizing: border-box;
 	flex: 0 0 auto;
+}
+
+.journal-day-metadata-row:not(.journal-day-metadata-tags) {
+	padding-block: var(--size-2-3);
+}
+
+.journal-day-metadata-row.journal-day-metadata-editing {
+	padding-block: var(--size-2-2);
 }
 
 .journal-day-metadata-label {
@@ -453,6 +462,12 @@ button.journal-day-metadata-value-button:focus-visible,
 
 .journal-day-property-input:not([type="checkbox"]) {
 	width: min(14rem, 38vw);
+}
+
+.journal-day-metadata-row.journal-day-metadata-editing .journal-day-property-input {
+	height: 20px;
+	min-height: 20px;
+	padding-block: 0;
 }
 
 .journal-day-property-input[type="checkbox"] {

--- a/styles.css
+++ b/styles.css
@@ -434,8 +434,12 @@ button.journal-day-metadata-value-button:focus-visible {
 	color: var(--text-accent);
 }
 
+button.journal-day-metadata-value-empty {
+	padding-inline: var(--size-2-2);
+}
+
 button.journal-day-metadata-value-button:focus-visible,
-.journal-day-tag:focus-visible,
+.journal-day-tag-remove:focus-visible,
 .journal-day-tag-add:focus-visible,
 .journal-day-metadata-clear:focus-visible {
 	outline: 2px solid var(--background-modifier-border-focus);
@@ -522,45 +526,86 @@ button.journal-day-metadata-value-button:focus-visible,
 	display: inline-flex;
 	align-items: center;
 	gap: var(--size-2-1);
+	font: inherit;
+	line-height: inherit;
+	height: 18px;
+	padding: 0 var(--size-2-2) 0 calc(var(--size-2-2) + 2px);
+	border-radius: var(--radius-s);
+	background-color: var(--background-modifier-hover);
+	color: var(--text-normal);
+	overflow-wrap: anywhere;
+	box-sizing: border-box;
+}
+
+.journal-day-tag-remove {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	appearance: none;
 	border: 0;
 	box-shadow: none;
-	font: inherit;
-	line-height: inherit;
-	height: auto;
-	padding: 1px var(--size-2-2);
-	border-radius: var(--radius-s);
-	background-color: var(--background-modifier-hover);
-	color: var(--text-accent);
-	overflow-wrap: anywhere;
-}
-
-button.journal-day-tag {
-	cursor: var(--cursor);
-}
-
-button.journal-day-tag:hover {
-	background-color: var(--background-modifier-active-hover);
-}
-
-.journal-day-tag-x {
+	background: transparent;
+	width: 12px;
+	height: 14px;
+	padding: 0;
 	color: var(--text-muted);
-	font-size: 1.1em;
-	line-height: 0.8;
+	font: inherit;
+	font-size: 1em;
+	line-height: 1;
+	cursor: var(--cursor);
+	transition: opacity 100ms ease-in-out, color 100ms ease-in-out;
+}
+
+.journal-day-tag-remove:hover {
+	color: var(--text-normal);
+}
+
+@media (hover: hover) {
+	.journal-day-tag-text {
+		transform: translateX(6px);
+		transition: transform 100ms ease-in-out;
+	}
+
+	.journal-day-tag-remove {
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.journal-day-tag:hover .journal-day-tag-text,
+	.journal-day-tag:focus-within .journal-day-tag-text {
+		transform: translateX(0);
+	}
+
+	.journal-day-tag:hover .journal-day-tag-remove,
+	.journal-day-tag:focus-within .journal-day-tag-remove {
+		opacity: 1;
+		pointer-events: auto;
+	}
 }
 
 .journal-day-tag-add {
-	--icon-size: var(--icon-xs);
-	width: 20px;
-	height: 20px;
+	--icon-size: 12px;
+	width: 18px;
+	min-width: 18px;
+	max-width: 18px;
+	height: 18px;
+	min-height: 18px;
+	max-height: 18px;
 	padding: 2px;
 	border-radius: var(--radius-s);
 	color: var(--text-muted);
 	background-color: var(--background-modifier-hover);
+	box-sizing: border-box;
 }
 
-.journal-day-tag-input {
+.journal-day-metadata-row.journal-day-metadata-tags .journal-day-tag-input {
 	width: min(9rem, 34vw);
+	height: 20px;
+	min-height: 20px;
+	max-height: 20px;
+	padding-block: 0;
+	margin: 0;
+	box-sizing: border-box;
 }
 
 .journal-day-body {
@@ -935,8 +980,31 @@ button.journal-picker-day.is-out-of-range:hover {
 	width: min(16rem, 45vw);
 }
 
+.journal-appearance-setting-name {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--size-2-2);
+}
+
+.journal-appearance-setting-icon {
+	display: inline-flex;
+	align-items: center;
+	color: var(--text-muted);
+}
+
+.journal-appearance-setting-icon svg {
+	width: var(--icon-xs);
+	height: var(--icon-xs);
+}
+
+.modal.journal-appearance-modal .modal-content .journal-appearance-properties-heading.setting-item {
+	padding-bottom: var(--size-2-2);
+}
+
 .modal.journal-appearance-modal .modal-content .journal-appearance-add-property.setting-item {
 	border-top: 0;
+	padding-top: var(--size-2-3);
+	padding-bottom: var(--size-2-3);
 }
 
 .journal-appearance-properties {
@@ -947,6 +1015,26 @@ button.journal-picker-day.is-out-of-range:hover {
 
 .journal-appearance-properties > .setting-item:first-child {
 	border-top: 1px solid var(--background-modifier-border);
+}
+
+.modal.journal-appearance-modal .modal-content .journal-appearance-properties > .setting-item {
+	align-items: center;
+	min-height: 0;
+	padding-top: var(--size-2-2);
+	padding-bottom: var(--size-2-2);
+}
+
+.modal.journal-appearance-modal
+	.modal-content
+	.journal-appearance-properties
+	> .setting-item
+	> .setting-item-info,
+.modal.journal-appearance-modal
+	.modal-content
+	.journal-appearance-properties
+	> .setting-item
+	> .setting-item-control {
+	align-self: center;
 }
 
 .journal-appearance-empty {

--- a/styles.css
+++ b/styles.css
@@ -407,6 +407,79 @@ button.journal-day-create:hover {
 	overflow-wrap: anywhere;
 }
 
+button.journal-day-metadata-value-button {
+	appearance: none;
+	border: 0;
+	box-shadow: none;
+	background: transparent;
+	font: inherit;
+	line-height: inherit;
+	text-align: start;
+	height: auto;
+	padding: 0;
+	cursor: text;
+}
+
+button.journal-day-metadata-value-button:hover,
+button.journal-day-metadata-value-button:focus-visible {
+	color: var(--text-accent);
+}
+
+button.journal-day-metadata-value-button:focus-visible,
+.journal-day-tag:focus-visible,
+.journal-day-tag-add:focus-visible,
+.journal-day-metadata-clear:focus-visible {
+	outline: 2px solid var(--background-modifier-border-focus);
+	outline-offset: 2px;
+}
+
+.journal-day-property-editor {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--size-2-1);
+	min-width: 0;
+	max-width: 100%;
+}
+
+.journal-day-property-input,
+.journal-day-tag-input {
+	height: 22px;
+	min-height: 22px;
+	padding: 1px var(--size-2-2);
+	border-radius: var(--input-radius);
+	font-size: inherit;
+	line-height: inherit;
+}
+
+.journal-day-property-input:not([type="checkbox"]) {
+	width: min(14rem, 38vw);
+}
+
+.journal-day-property-input[type="checkbox"] {
+	width: var(--checkbox-size);
+	height: var(--checkbox-size);
+	min-height: 0;
+	margin: 0;
+}
+
+.journal-day-property-input.is-invalid,
+.journal-day-tag-input.is-invalid {
+	border-color: var(--text-error);
+	box-shadow: 0 0 0 1px var(--text-error);
+}
+
+.journal-day-metadata-clear {
+	--icon-size: var(--icon-xs);
+	width: 20px;
+	height: 20px;
+	padding: 2px;
+	color: var(--text-muted);
+}
+
+.journal-day-metadata-pending {
+	opacity: 0.65;
+}
+
 .journal-day-metadata-tags {
 	align-items: center;
 }
@@ -431,11 +504,48 @@ button.journal-day-create:hover {
 }
 
 .journal-day-tag {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--size-2-1);
+	appearance: none;
+	border: 0;
+	box-shadow: none;
+	font: inherit;
+	line-height: inherit;
+	height: auto;
 	padding: 1px var(--size-2-2);
 	border-radius: var(--radius-s);
 	background-color: var(--background-modifier-hover);
 	color: var(--text-accent);
 	overflow-wrap: anywhere;
+}
+
+button.journal-day-tag {
+	cursor: var(--cursor);
+}
+
+button.journal-day-tag:hover {
+	background-color: var(--background-modifier-active-hover);
+}
+
+.journal-day-tag-x {
+	color: var(--text-muted);
+	font-size: 1.1em;
+	line-height: 0.8;
+}
+
+.journal-day-tag-add {
+	--icon-size: var(--icon-xs);
+	width: 20px;
+	height: 20px;
+	padding: 2px;
+	border-radius: var(--radius-s);
+	color: var(--text-muted);
+	background-color: var(--background-modifier-hover);
+}
+
+.journal-day-tag-input {
+	width: min(9rem, 34vw);
 }
 
 .journal-day-body {

--- a/styles.css
+++ b/styles.css
@@ -1057,6 +1057,26 @@ button.journal-picker-day.is-out-of-range:hover {
 	padding: var(--size-4-3) 0;
 }
 
+button.journal-appearance-settings-link {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: max-content;
+	height: auto;
+	margin: var(--size-4-3) auto 0;
+	padding: var(--size-2-2) var(--size-4-2);
+	border: 0;
+	box-shadow: none;
+	background-color: var(--background-modifier-hover);
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}
+
+button.journal-appearance-settings-link:hover {
+	background-color: var(--background-modifier-border);
+	color: var(--text-normal);
+}
+
 /* -------------------------------------------------------------- settings -- */
 
 .journal-settings-note {


### PR DESCRIPTION
## Summary

- Add a Customization modal with global controls for frontmatter tags and an ordered property list
- Render responsive metadata boxes above existing daily-note bodies without affecting Journal Find or editor state
- Allow type-aware inline property editing, deletion by clearing, and frontmatter tag add/remove with vault-wide autocomplete
- Serialize atomic frontmatter writes so metadata edits preserve dirty body text, external changes, and updates from other journal panes
- Keep the tags box available on existing tagless notes and document the editable controls

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Reloaded the plugin in the throwaway vault and exercised missing, string, numeric, boolean, array, nested, empty, and invalid property values
- Verified case-preserving property updates, deletion by clearing, tag autocomplete/free-form entry, duplicate rejection, removal, and tagless-note controls
- Verified focused drafts survive external refreshes and body saves preserve concurrently edited frontmatter
- Verified serialized writes across multiple journal panes, immediate pane teardown, write-failure recovery, responsive wrapping, empty-day exclusion, and body-only Journal Find
- Confirmed `dev:errors` remained clean