### PR TITLE
Add journal note filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Open Journal View from the sidebar or run **Open journal** from the command pale
   the daily note only when you need it.
 - **Rediscover past entries.** Search across your journal to quickly find notes, ideas, and memories
   from any day.
+- **Focus the timeline.** Filter daily notes by tags or exact property values, with include and
+  exclude rules that also carry through to calendar navigation and journal search.
 - **Stay responsive across years of notes.** Journal View keeps the days around you ready to edit
   while efficiently handling the rest of your timeline.
 
@@ -42,6 +44,22 @@ Some Customization is only visible in the customization menu accessible from the
 | Rich editor | On | Uses Obsidian's Markdown editor; turn it off to use the plain-text fallback |
 | Autosave delay | 2000 ms | Sets how long Journal View waits after typing before saving |
 | Days kept loaded | 60 | Sets the target number of days kept in the timeline; dropped days reload when you scroll back to them |
+
+## Filters
+
+Select the funnel button in the journal toolbar to open the filters. **Show only days with notes** is
+enabled by default; Today remains visible even when it is empty or does not match the metadata
+filters. Turn that option off to keep empty days available for writing while still hiding existing
+notes that do not match.
+
+Tag filters use tags from both frontmatter and note content. A parent tag also matches its nested
+tags, so `#project` matches `#project/client`. Property filters compare exact string, number, or
+boolean values, and a list property matches when one of its items equals the configured value.
+
+Every include filter must match. A note matching any exclude filter is hidden, even if it satisfies
+all includes. The funnel uses the accent color whenever a tag or property filter is active; the
+note-only toggle does not highlight it. Filtered dates are disabled in **Go to date**, and **Find in
+journal** searches only the notes currently included.
 
 ## Privacy
 

--- a/src/datePicker.ts
+++ b/src/datePicker.ts
@@ -2,7 +2,8 @@ import { App, Modal, moment } from "obsidian";
 import { MAX_OFFSET } from "./dayWalk";
 import { createMoment } from "./moment";
 import type { Moment } from "./moment";
-import { DAY_KEY_FORMAT, DailyNoteIndex } from "./noteIndex";
+import { DAY_KEY_FORMAT } from "./noteIndex";
+import type { OrderedDayIndex } from "./noteIndex";
 
 /** Months built either side of the current one when the picker opens. */
 const INITIAL_MONTHS = 6;
@@ -15,13 +16,15 @@ const MAX_MONTHS = 36;
 
 export interface DatePickerOptions {
 	/** Which days have a note, for the dots under the numbers. */
-	index: DailyNoteIndex;
+	index: OrderedDayIndex;
 	/** Today, as the view measures it. */
 	today: Moment;
 	/** The day the journal is currently showing, if it has one. */
 	current?: Moment;
 	/** Indexed notes beyond the empty-day safety range can be opened. */
 	allowDistantNotes: boolean;
+	/** The timeline's complete visibility rule, including empty days and Today. */
+	isVisible(date: Moment): boolean;
 	onPick(date: Moment): void;
 	/** Called whenever the picker goes away, however it was dismissed. */
 	onDismiss?(): void;
@@ -303,6 +306,7 @@ export class DatePickerModal extends Modal {
 			attr: { type: "button", "data-date": key, "aria-label": date.format("dddd, D MMMM YYYY") },
 		});
 
+		const visible = this.options.isVisible(date);
 		if (this.options.index.has(key)) cell.addClass("has-note");
 		if (key === this.todayKey) {
 			cell.addClass("is-today");
@@ -314,7 +318,7 @@ export class DatePickerModal extends Modal {
 		}
 		const inStandardRange = key >= this.standardMinKey && key <= this.standardMaxKey;
 		const isDistantNote = this.options.allowDistantNotes && this.options.index.has(key);
-		if (!inStandardRange && !isDistantNote) {
+		if ((!inStandardRange && !isDistantNote) || !visible) {
 			cell.addClass("is-out-of-range");
 			cell.disabled = true;
 			return cell;

--- a/src/day.ts
+++ b/src/day.ts
@@ -105,12 +105,14 @@ export interface DayHost {
 	plugin: JournalViewPlugin;
 	/** Called when a day's underlying file appears, disappears or is renamed. */
 	onDayFileChanged(day: DaySection, previousPath: string | null): void;
-	/** True for a day that stays in the journal even with empty days hidden. */
-	isPinnedDay(day: DaySection): boolean;
+	/** True when this date passes the journal's current visibility rules. */
+	isVisibleDay(day: DaySection): boolean;
 	/** True while a day is out of sight, where its body can be swapped unseen. */
 	isOffScreen(day: DaySection): boolean;
 	/** Re-indexes find results after this day's visible body changes. */
 	onDayContentChanged(day: DaySection): void;
+	/** Re-applies filtering after a focused editing session settles. */
+	onDayFocusChanged(day: DaySection): void;
 	/** Re-centres a navigation after focus-driven editor and template layout settles. */
 	onDayFocusSettled(day: DaySection): void;
 	/** Opens the journal-wide find UI from an embedded editor command. */
@@ -384,6 +386,14 @@ export class DaySection {
 		this.bodyEl = this.cardEl.createDiv({ cls: "journal-day-body" });
 
 		this.el.addEventListener("click", (event) => this.onClick(event));
+		this.el.addEventListener("focusout", () => {
+			// Focus often moves between the editor and metadata controls inside the
+			// same day. Wait for that move to settle before releasing the temporary
+			// focused-day visibility guard.
+			window.setTimeout(() => {
+				if (!this.destroyed && !this.hasFocus) this.host.onDayFocusChanged(this);
+			}, 0);
+		});
 
 		this.refreshState();
 	}
@@ -552,10 +562,7 @@ export class DaySection {
 		this.el.toggleClass("journal-day-today", this.isToday);
 		this.el.toggleClass("journal-day-empty", !this.exists);
 		this.el.toggleClass("journal-day-future", this.offset > 0);
-		this.el.toggleClass(
-			"journal-day-hidden",
-			!this.exists && !this.host.isPinnedDay(this) && this.host.plugin.settings.hideEmptyDays,
-		);
+		this.refreshVisibility();
 
 		this.bodyEl.dataset.placeholder = this.exists ? "Empty note" : "Start typing to create this note";
 		this.actionsEl.empty();
@@ -591,6 +598,11 @@ export class DaySection {
 			});
 		}
 		this.refreshMetadata();
+	}
+
+	/** Re-applies only the state that can change when focus leaves a filtered day. */
+	refreshVisibility(): void {
+		this.el.toggleClass("journal-day-hidden", !this.host.isVisibleDay(this));
 	}
 
 	/** Rebuilds the editable strip from the latest complete note content. */
@@ -1718,7 +1730,9 @@ export class DaySection {
 		this.el.removeClass("journal-day-focused");
 		// Leaving a day the reader only looked at costs them nothing.
 		if (this.withdrawTemplate()) return;
-		void this.flush();
+		void this.flush().finally(() => {
+			if (!this.destroyed) this.host.onDayFocusChanged(this);
+		});
 	}
 
 	/**

--- a/src/dayWalk.ts
+++ b/src/dayWalk.ts
@@ -1,6 +1,7 @@
 import { createMoment } from "./moment";
 import type { Moment } from "./moment";
-import { DAY_KEY_FORMAT, DailyNoteIndex } from "./noteIndex";
+import { DAY_KEY_FORMAT } from "./noteIndex";
+import type { OrderedDayIndex } from "./noteIndex";
 
 /** Hard stop so empty-day scrolling cannot allocate forever (~13 years). */
 export const MAX_OFFSET = 5000;
@@ -26,21 +27,16 @@ export function isOffsetReachable(offset: number, hideEmpty: boolean, indexed: b
  */
 export class DayWalker {
 	/**
-	 * Days the filter is not allowed to take away, as offsets: today, and the
-	 * day the view was last sent to. Sorted, so a walk can ask which comes next.
+	 * Today is the only date the filter is not allowed to take away.
 	 */
-	private readonly pinned: number[];
+	private readonly pinned = [0];
 
 	constructor(
 		readonly today: Moment,
-		private index: DailyNoteIndex,
+		private notes: OrderedDayIndex,
+		private matchingNotes: OrderedDayIndex,
 		private hideEmpty: () => boolean,
-		pinned?: Moment,
-	) {
-		const offset = pinned ? pinned.clone().startOf("day").diff(today, "days") : 0;
-		const kept = this.isReachable(offset) ? [0, offset] : [0];
-		this.pinned = Array.from(new Set(kept)).sort((a, b) => a - b);
-	}
+	) {}
 
 	dateFor(offset: number): Moment {
 		return this.today.clone().add(offset, "days");
@@ -56,15 +52,14 @@ export class DayWalker {
 
 	/**
 	 * The next day the view should render in `direction`. With empty days
-	 * hidden this skips straight to the next day that actually has a note, so
+	 * hidden this skips straight to the next matching note, so
 	 * the view never has to materialise a run of blank days to cross a gap -
-	 * except for a pinned day, which belongs in the journal whether it has a
-	 * note or not, so a walk that would step over one stops there instead.
+	 * except for Today, so a walk that would step over it stops there instead.
 	 */
 	next(from: number, direction: -1 | 1): number | null {
 		if (this.hideEmpty()) {
 			const key = this.keyFor(from);
-			const found = direction < 0 ? this.index.prev(key) : this.index.next(key);
+			const found = direction < 0 ? this.matchingNotes.prev(key) : this.matchingNotes.next(key);
 			const noted = found ? this.offsetFor(found) : null;
 			// Whichever comes first: the next day with a note, or the next day
 			// that is kept regardless.
@@ -76,8 +71,19 @@ export class DayWalker {
 			// were checked when the walker was built.
 			return direction < 0 ? Math.max(...candidates) : Math.min(...candidates);
 		}
-		const offset = from + direction;
-		return isOffsetReachable(offset, false, false) ? offset : null;
+		let offset = from + direction;
+		while (isOffsetReachable(offset, false, false)) {
+			if (this.isVisible(offset)) return offset;
+			offset += direction;
+		}
+		return null;
+	}
+
+	/** Whether this date belongs in the filtered journal. Today is unconditional. */
+	isVisible(offset: number): boolean {
+		if (this.isPinned(offset)) return true;
+		const key = this.keyFor(offset);
+		return this.notes.has(key) ? this.matchingNotes.has(key) : !this.hideEmpty();
 	}
 
 	/** True for a day that is shown whether or not it has a note. */
@@ -96,17 +102,15 @@ export class DayWalker {
 	}
 
 	/**
-	 * The offset a window should be built around. Hiding empty days can take
-	 * away the very day the reader was looking at, so an anchor that will not
-	 * survive is moved to whichever surviving day is closest to it - unless it
-	 * is pinned, which is how a day the reader asked for by date is kept.
+	 * The offset a window should be built around. Filters can take away the day
+	 * the reader was looking at, so a non-surviving anchor moves to the nearest
+	 * visible date instead.
 	 */
 	origin(around?: Moment): number {
 		if (!around) return 0;
 		const offset = around.clone().startOf("day").diff(this.today, "days");
 		if (!this.isReachable(offset)) return 0;
-		if (!this.hideEmpty()) return offset;
-		if (this.isPinned(offset) || this.index.has(this.keyFor(offset))) return offset;
+		if (this.isVisible(offset)) return offset;
 
 		const before = this.next(offset, -1);
 		const after = this.next(offset, 1);
@@ -116,6 +120,6 @@ export class DayWalker {
 	}
 
 	private isReachable(offset: number): boolean {
-		return isOffsetReachable(offset, this.hideEmpty(), this.index.has(this.keyFor(offset)));
+		return isOffsetReachable(offset, this.hideEmpty(), this.matchingNotes.has(this.keyFor(offset)));
 	}
 }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,0 +1,276 @@
+import { App, TFile, getAllTags } from "obsidian";
+import type { CachedMetadata } from "obsidian";
+import type { DailyNoteIndex, OrderedDayIndex } from "./noteIndex";
+import type {
+	JournalFilterMode,
+	JournalFilterRule,
+	JournalFilterValue,
+	JournalViewSettings,
+} from "./settings";
+
+/** Removes Obsidian's display prefix and produces the comparison form of a tag. */
+export function normalizeFilterTag(value: string): string {
+	return value.trim().replace(/^#+/, "").replace(/\/+$/g, "").toLocaleLowerCase();
+}
+
+export function isFilterActive(settings: JournalViewSettings): boolean {
+	return settings.filterRules.length > 0;
+}
+
+function isFilterMode(value: unknown): value is JournalFilterMode {
+	return value === "include" || value === "exclude";
+}
+
+function isFilterValue(value: unknown): value is JournalFilterValue {
+	return (
+		typeof value === "string" ||
+		typeof value === "boolean" ||
+		(typeof value === "number" && Number.isFinite(value))
+	);
+}
+
+/** Validates persisted rules while normalising the identifiers used for matching. */
+export function filterRulesSetting(value: unknown): JournalFilterRule[] {
+	if (!Array.isArray(value)) return [];
+	const rules: JournalFilterRule[] = [];
+	for (const item of value) {
+		if (!item || typeof item !== "object") continue;
+		const candidate = item as Record<string, unknown>;
+		if (!isFilterMode(candidate.mode)) continue;
+		if (candidate.kind === "tag" && typeof candidate.tag === "string") {
+			const tag = normalizeFilterTag(candidate.tag);
+			if (tag) rules.push({ kind: "tag", mode: candidate.mode, tag });
+			continue;
+		}
+		if (
+			candidate.kind === "property" &&
+			typeof candidate.property === "string" &&
+			isFilterValue(candidate.value)
+		) {
+			const property = candidate.property.trim();
+			if (property && !["tags", "position"].includes(property.toLocaleLowerCase())) {
+				rules.push({ kind: "property", mode: candidate.mode, property, value: candidate.value });
+			}
+		}
+	}
+	return dedupeFilterRules(rules);
+}
+
+export function sameFilterValue(left: JournalFilterValue, right: JournalFilterValue): boolean {
+	return typeof left === typeof right && left === right;
+}
+
+export function sameFilterRule(left: JournalFilterRule, right: JournalFilterRule): boolean {
+	if (left.kind !== right.kind || left.mode !== right.mode) return false;
+	if (left.kind === "tag" && right.kind === "tag") return left.tag === right.tag;
+	return (
+		left.kind === "property" &&
+		right.kind === "property" &&
+		left.property.toLocaleLowerCase() === right.property.toLocaleLowerCase() &&
+		sameFilterValue(left.value, right.value)
+	);
+}
+
+function dedupeFilterRules(rules: JournalFilterRule[]): JournalFilterRule[] {
+	const result: JournalFilterRule[] = [];
+	for (const rule of rules) {
+		if (!result.some((current) => sameFilterRule(current, rule))) result.push(rule);
+	}
+	return result;
+}
+
+function tagMatches(candidate: string, filter: string): boolean {
+	const tag = normalizeFilterTag(candidate);
+	return tag === filter || tag.startsWith(`${filter}/`);
+}
+
+function propertyValueMatches(stored: unknown, expected: JournalFilterValue): boolean {
+	if (Array.isArray(stored)) {
+		return stored.some((item) => isFilterValue(item) && sameFilterValue(item, expected));
+	}
+	return isFilterValue(stored) && sameFilterValue(stored, expected);
+}
+
+function ruleMatches(cache: CachedMetadata | null, rule: JournalFilterRule): boolean {
+	if (rule.kind === "tag") {
+		return (getAllTags(cache ?? {}) ?? []).some((tag) => tagMatches(tag, rule.tag));
+	}
+
+	const frontmatter = cache?.frontmatter;
+	if (!frontmatter) return false;
+	const expected = rule.property.toLocaleLowerCase();
+	const actual = Object.keys(frontmatter).find((key) => key.toLocaleLowerCase() === expected);
+	return actual !== undefined && propertyValueMatches(frontmatter[actual], rule.value);
+}
+
+/** Existing notes match every include rule unless an exclude rule vetoes them. */
+export function matchesFilterRules(cache: CachedMetadata | null, rules: JournalFilterRule[]): boolean {
+	for (const rule of rules) {
+		const matches = ruleMatches(cache, rule);
+		if (rule.mode === "include" && !matches) return false;
+		if (rule.mode === "exclude" && matches) return false;
+	}
+	return true;
+}
+
+/**
+ * Ordered projection of the daily-note index containing only notes accepted by
+ * the metadata rules. It stays separate from existence so empty-day visibility
+ * can remain an independent setting.
+ */
+export class FilteredDailyNoteIndex implements OrderedDayIndex {
+	private keys = new Set<string>();
+	private sorted: string[] = [];
+	private sortedDirty = true;
+	private matchingPaths = new Set<string>();
+	private pathKeys = new Map<string, string>();
+	private matchingCounts = new Map<string, number>();
+	private signature = "";
+	private baseVersion = -1;
+
+	version = 0;
+
+	constructor(
+		private app: App,
+		private base: DailyNoteIndex,
+		private getRules: () => JournalFilterRule[],
+	) {}
+
+	rebuild(): void {
+		this.base.ensureCurrent();
+		this.keys.clear();
+		this.matchingPaths.clear();
+		this.pathKeys.clear();
+		this.matchingCounts.clear();
+		const rules = this.getRules();
+		const config = this.base.resolvedConfig();
+		for (const file of this.app.vault.getMarkdownFiles()) {
+			const key = this.base.keyForPath(file.path, config);
+			if (!key) continue;
+			this.pathKeys.set(file.path, key);
+			if (!matchesFilterRules(this.app.metadataCache.getFileCache(file), rules)) continue;
+			this.matchingPaths.add(file.path);
+			this.matchingCounts.set(key, (this.matchingCounts.get(key) ?? 0) + 1);
+			this.keys.add(key);
+		}
+		this.signature = JSON.stringify(rules);
+		this.baseVersion = this.base.version;
+		this.sortedDirty = true;
+		this.version++;
+	}
+
+	ensureCurrent(): void {
+		this.base.ensureCurrent();
+		if (this.base.version !== this.baseVersion || JSON.stringify(this.getRules()) !== this.signature) {
+			this.rebuild();
+		}
+	}
+
+	/** Re-evaluates one note after Obsidian has refreshed its metadata cache. */
+	handleMetadataChange(file: TFile): boolean {
+		this.ensureCurrent();
+		const key = this.base.keyForPath(file.path);
+		const previousKey = this.pathKeys.get(file.path);
+		let membershipChanged = false;
+		if (previousKey && previousKey !== key) {
+			membershipChanged = this.removeMatchingPath(file.path, previousKey);
+		}
+		if (!key) {
+			this.pathKeys.delete(file.path);
+			if (membershipChanged) {
+				this.sortedDirty = true;
+				this.version++;
+			}
+			return membershipChanged;
+		}
+
+		this.pathKeys.set(file.path, key);
+		const wasMatching = this.matchingPaths.has(file.path);
+		const matches = matchesFilterRules(this.app.metadataCache.getFileCache(file), this.getRules());
+		if (matches === wasMatching && previousKey === key) return false;
+		if (wasMatching) membershipChanged = this.removeMatchingPath(file.path, previousKey ?? key) || membershipChanged;
+		if (matches) {
+			this.addMatchingPath(file.path, key);
+			membershipChanged = true;
+		}
+		if (membershipChanged) {
+			this.sortedDirty = true;
+			this.version++;
+		}
+		return membershipChanged;
+	}
+
+	has(key: string): boolean {
+		return this.keys.has(key);
+	}
+
+	get size(): number {
+		return this.keys.size;
+	}
+
+	range(): { first: string; last: string } | null {
+		const list = this.list();
+		return list.length ? { first: list[0], last: list[list.length - 1] } : null;
+	}
+
+	next(key: string): string | null {
+		const list = this.list();
+		let low = 0;
+		let high = list.length;
+		while (low < high) {
+			const mid = (low + high) >> 1;
+			if (list[mid] <= key) low = mid + 1;
+			else high = mid;
+		}
+		return low < list.length ? list[low] : null;
+	}
+
+	prev(key: string): string | null {
+		const list = this.list();
+		let low = 0;
+		let high = list.length;
+		while (low < high) {
+			const mid = (low + high) >> 1;
+			if (list[mid] < key) low = mid + 1;
+			else high = mid;
+		}
+		return low > 0 ? list[low - 1] : null;
+	}
+
+	keysFrom(key: string, direction: -1 | 1): string[] {
+		const list = this.list();
+		if (direction > 0) {
+			return [...list.filter((candidate) => candidate > key), ...list.filter((candidate) => candidate < key)];
+		}
+		return [
+			...list.filter((candidate) => candidate < key).reverse(),
+			...list.filter((candidate) => candidate > key).reverse(),
+		];
+	}
+
+	private addMatchingPath(path: string, key: string): void {
+		this.matchingPaths.add(path);
+		const count = (this.matchingCounts.get(key) ?? 0) + 1;
+		this.matchingCounts.set(key, count);
+		if (count === 1) this.keys.add(key);
+	}
+
+	private removeMatchingPath(path: string, key: string): boolean {
+		if (!this.matchingPaths.delete(path)) return false;
+		const count = (this.matchingCounts.get(key) ?? 1) - 1;
+		if (count > 0) this.matchingCounts.set(key, count);
+		else {
+			this.matchingCounts.delete(key);
+			this.keys.delete(key);
+		}
+		return true;
+	}
+
+	private list(): string[] {
+		if (this.sortedDirty) {
+			this.sorted = Array.from(this.keys).sort();
+			this.sortedDirty = false;
+		}
+		return this.sorted;
+	}
+}

--- a/src/filterModal.ts
+++ b/src/filterModal.ts
@@ -1,0 +1,414 @@
+import { AbstractInputSuggest, App, Modal, Notice, Setting, getAllTags } from "obsidian";
+import type { CachedMetadata, ToggleComponent } from "obsidian";
+import {
+	normalizeFilterTag,
+	sameFilterRule,
+	sameFilterValue,
+} from "./filter";
+import type JournalViewPlugin from "./main";
+import type {
+	JournalFilterMode,
+	JournalFilterRule,
+	JournalFilterValue,
+} from "./settings";
+
+interface FilterModalOptions {
+	onDismiss?(): void;
+}
+
+interface ValueOption {
+	label: string;
+	input: string;
+	value: JournalFilterValue;
+}
+
+class TextSuggest extends AbstractInputSuggest<string> {
+	constructor(
+		app: App,
+		input: HTMLInputElement,
+		private readonly items: () => string[],
+		private readonly display: (value: string) => string = (value) => value,
+		private readonly selected?: (value: string) => void,
+	) {
+		super(app, input);
+	}
+
+	protected getSuggestions(query: string): string[] {
+		const needle = query.trim().replace(/^#/, "").toLocaleLowerCase();
+		return this.items().filter((item) => !needle || item.toLocaleLowerCase().includes(needle));
+	}
+
+	renderSuggestion(value: string, el: HTMLElement): void {
+		el.setText(this.display(value));
+	}
+
+	selectSuggestion(value: string): void {
+		this.setValue(this.display(value));
+		this.close();
+		this.selected?.(value);
+	}
+}
+
+class ValueSuggest extends AbstractInputSuggest<ValueOption> {
+	constructor(
+		app: App,
+		input: HTMLInputElement,
+		private readonly items: () => ValueOption[],
+		private readonly selected: (option: ValueOption) => void,
+	) {
+		super(app, input);
+	}
+
+	protected getSuggestions(query: string): ValueOption[] {
+		const needle = query.trim().toLocaleLowerCase();
+		return this.items().filter((item) => !needle || item.label.toLocaleLowerCase().includes(needle));
+	}
+
+	renderSuggestion(option: ValueOption, el: HTMLElement): void {
+		el.setText(option.label);
+	}
+
+	selectSuggestion(option: ValueOption): void {
+		this.setValue(option.input);
+		this.close();
+		this.selected(option);
+	}
+}
+
+const NUMBER_VALUE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i;
+
+function parseValueInput(raw: string): { valid: boolean; value?: JournalFilterValue } {
+	const value = raw.trim();
+	if (!value) return { valid: false };
+	if (value.startsWith('"') && value.endsWith('"')) {
+		try {
+			const parsed: unknown = JSON.parse(value);
+			if (typeof parsed === "string") return { valid: true, value: parsed };
+		} catch {
+			return { valid: false };
+		}
+	}
+	if (value === "true" || value === "false") return { valid: true, value: value === "true" };
+	if (NUMBER_VALUE.test(value)) {
+		const number = Number(value);
+		if (Number.isFinite(number)) return { valid: true, value: number };
+	}
+	return { valid: true, value };
+}
+
+function valueInput(value: JournalFilterValue): string {
+	if (typeof value !== "string") return String(value);
+	return value === "true" || value === "false" || NUMBER_VALUE.test(value) || !value.trim()
+		? JSON.stringify(value)
+		: value;
+}
+
+function valueLabel(value: JournalFilterValue): string {
+	const shown = typeof value === "string" ? JSON.stringify(value) : String(value);
+	return `${shown} · ${typeof value}`;
+}
+
+function ruleLabel(rule: JournalFilterRule): string {
+	const mode = rule.mode === "include" ? "Include" : "Exclude";
+	if (rule.kind === "tag") return `${mode} tag #${rule.tag}`;
+	const value = typeof rule.value === "string" ? JSON.stringify(rule.value) : String(rule.value);
+	return `${mode} ${rule.property} = ${value}`;
+}
+
+/** Persistent global controls for which dates belong in the journal. */
+export class FilterModal extends Modal {
+	private mode: JournalFilterMode = "include";
+	private kind: JournalFilterRule["kind"] = "tag";
+	private tagInput!: HTMLInputElement;
+	private propertyInput!: HTMLInputElement;
+	private valueInput!: HTMLInputElement;
+	private addButton!: HTMLButtonElement;
+	private addSettingEl!: HTMLElement;
+	private listEl!: HTMLElement;
+	private hideEmptyToggle!: ToggleComponent;
+	private stopControlSync: (() => void) | null = null;
+	private tagSuggest: TextSuggest | null = null;
+	private propertySuggest: TextSuggest | null = null;
+	private valueSuggest: ValueSuggest | null = null;
+	private tags: string[] = [];
+	private properties = new Map<string, string>();
+	private propertyValues = new Map<string, JournalFilterValue[]>();
+	private selectedValue: ValueOption | null = null;
+	private saving: Promise<void> = Promise.resolve();
+
+	constructor(
+		app: App,
+		private plugin: JournalViewPlugin,
+		private options: FilterModalOptions = {},
+	) {
+		super(app);
+	}
+
+	onOpen(): void {
+		this.modalEl.addClass("journal-filter-modal");
+		this.titleEl.setText("Filter notes");
+		this.discoverMetadata();
+
+		new Setting(this.contentEl)
+			.setName("Show only days with notes")
+			.setDesc("Hide empty dates. Today is always shown.")
+			.addToggle((toggle) =>
+				(this.hideEmptyToggle = toggle).setValue(this.plugin.settings.hideEmptyDays).onChange((value) => {
+					this.plugin.settings.hideEmptyDays = value;
+					this.persist();
+				}),
+			);
+		this.stopControlSync = this.plugin.onFilterControlsChanged(() => {
+			this.hideEmptyToggle.setValue(this.plugin.settings.hideEmptyDays);
+		});
+
+		new Setting(this.contentEl)
+			.setName("Tag and property filters")
+			.setDesc("All include filters must match. Any matching exclude filter hides the note.")
+			.setClass("journal-filter-metadata-heading");
+
+		const add = new Setting(this.contentEl).setName("Add filter").setClass("journal-filter-add");
+		this.addSettingEl = add.settingEl;
+		add.addDropdown((dropdown) => {
+			dropdown.addOption("include", "Include").addOption("exclude", "Exclude").setValue(this.mode);
+			dropdown.selectEl.setAttribute("aria-label", "Filter mode");
+			dropdown.onChange((value) => {
+				this.mode = value === "exclude" ? "exclude" : "include";
+			});
+		});
+		add.addDropdown((dropdown) => {
+			dropdown.addOption("tag", "Tag").addOption("property", "Property").setValue(this.kind);
+			dropdown.selectEl.setAttribute("aria-label", "Filter type");
+			dropdown.onChange((value) => {
+				this.kind = value === "property" ? "property" : "tag";
+				this.syncEditor();
+			});
+		});
+		add.addText((text) => {
+			text.setPlaceholder("Tag").onChange(() => this.syncAddButton());
+			this.tagInput = text.inputEl;
+			this.tagInput.setAttribute("aria-label", "Tag");
+			this.tagInput.addEventListener("keydown", (event) => this.onInputKeydown(event));
+		});
+		add.addText((text) => {
+			text.setPlaceholder("Property").onChange(() => {
+				this.selectedValue = null;
+				this.syncAddButton();
+			});
+			this.propertyInput = text.inputEl;
+			this.propertyInput.setAttribute("aria-label", "Property name");
+			this.propertyInput.addEventListener("keydown", (event) => this.onInputKeydown(event));
+		});
+		add.addText((text) => {
+			text.setPlaceholder("Value").onChange(() => {
+				if (this.selectedValue?.input !== this.valueInput.value) this.selectedValue = null;
+				this.syncAddButton();
+			});
+			this.valueInput = text.inputEl;
+			this.valueInput.setAttribute("aria-label", "Property value");
+			this.valueInput.addEventListener("keydown", (event) => this.onInputKeydown(event));
+		});
+		add.addButton((button) => {
+			button.setButtonText("Add").setCta().setDisabled(true);
+			this.addButton = button.buttonEl;
+			this.addButton.type = "button";
+			// Commit before the pointer blurs an open autocomplete popover, which
+			// can otherwise consume the gesture while it dismisses itself.
+			this.addButton.addEventListener("pointerdown", (event) => {
+				if (event.button !== 0 || this.addButton.disabled) return;
+				event.preventDefault();
+				this.addRule();
+			});
+			// Keyboard and assistive clicks do not have a pointer event.
+			this.addButton.addEventListener("click", (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				if (event.detail === 0 && !this.addButton.disabled) this.addRule();
+			});
+		});
+
+		this.tagSuggest = new TextSuggest(
+			this.app,
+			this.tagInput,
+			() => this.tags,
+			(value) => `#${value}`,
+			() => this.syncAddButton(),
+		);
+		this.propertySuggest = new TextSuggest(
+			this.app,
+			this.propertyInput,
+			() => Array.from(this.properties.values()),
+			undefined,
+			() => {
+				this.selectedValue = null;
+				this.syncAddButton();
+			},
+		);
+		this.valueSuggest = new ValueSuggest(
+			this.app,
+			this.valueInput,
+			() => this.availableValues(),
+			(option) => {
+				this.selectedValue = option;
+				this.syncAddButton();
+			},
+		);
+
+		this.listEl = this.contentEl.createDiv({ cls: "journal-filter-rules" });
+		this.renderRules();
+		this.syncEditor();
+	}
+
+	onClose(): void {
+		this.stopControlSync?.();
+		this.stopControlSync = null;
+		this.tagSuggest?.close();
+		this.propertySuggest?.close();
+		this.valueSuggest?.close();
+		this.tagSuggest = this.propertySuggest = null;
+		this.valueSuggest = null;
+		this.contentEl.empty();
+		this.options.onDismiss?.();
+	}
+
+	private discoverMetadata(): void {
+		this.plugin.index.ensureCurrent();
+		const tags = new Set<string>();
+		for (const file of this.app.vault.getMarkdownFiles()) {
+			if (this.plugin.index.keyForPath(file.path) === null) continue;
+			const cache = this.app.metadataCache.getFileCache(file);
+			for (const rawTag of getAllTags(cache ?? {}) ?? []) {
+				const tag = normalizeFilterTag(rawTag);
+				if (tag) tags.add(tag);
+			}
+			this.discoverProperties(cache);
+		}
+		this.tags = Array.from(tags).sort((left, right) => left.localeCompare(right));
+	}
+
+	private discoverProperties(cache: CachedMetadata | null): void {
+		if (!cache?.frontmatter) return;
+		for (const [rawName, stored] of Object.entries(cache.frontmatter)) {
+			const property = rawName.trim();
+			const key = property.toLocaleLowerCase();
+			if (!property || key === "tags" || key === "position") continue;
+			if (!this.properties.has(key)) this.properties.set(key, property);
+			const values = this.propertyValues.get(key) ?? [];
+			const candidates = Array.isArray(stored) ? stored : [stored];
+			for (const value of candidates) {
+				if (
+					(typeof value === "string" || typeof value === "boolean" ||
+						(typeof value === "number" && Number.isFinite(value))) &&
+					!values.some((current) => sameFilterValue(current, value))
+				) {
+					values.push(value);
+				}
+			}
+			this.propertyValues.set(key, values);
+		}
+	}
+
+	private availableValues(): ValueOption[] {
+		const key = this.propertyInput.value.trim().toLocaleLowerCase();
+		return (this.propertyValues.get(key) ?? [])
+			.map((value) => ({ label: valueLabel(value), input: valueInput(value), value }))
+			.sort((left, right) => left.label.localeCompare(right.label));
+	}
+
+	private syncEditor(): void {
+		const tag = this.kind === "tag";
+		this.addSettingEl.toggleClass("is-property", !tag);
+		this.tagInput.toggleAttribute("hidden", !tag);
+		this.propertyInput.toggleAttribute("hidden", tag);
+		this.valueInput.toggleAttribute("hidden", tag);
+		this.syncAddButton();
+	}
+
+	private syncAddButton(): void {
+		if (!this.addButton) return;
+		if (this.kind === "tag") {
+			this.addButton.disabled = !normalizeFilterTag(this.tagInput.value);
+			return;
+		}
+		const hasValue = this.selectedValue !== null || parseValueInput(this.valueInput.value).valid;
+		this.addButton.disabled = !this.propertyInput.value.trim() || !hasValue;
+	}
+
+	private onInputKeydown(event: KeyboardEvent): void {
+		if (event.key !== "Enter" || event.isComposing || this.addButton.disabled) return;
+		event.preventDefault();
+		this.addRule();
+	}
+
+	private addRule(): void {
+		let rule: JournalFilterRule;
+		if (this.kind === "tag") {
+			const tag = normalizeFilterTag(this.tagInput.value);
+			if (!tag) return;
+			rule = { kind: "tag", mode: this.mode, tag };
+		} else {
+			const property = this.propertyInput.value.trim();
+			if (["tags", "position"].includes(property.toLocaleLowerCase())) {
+				new Notice(
+					property.toLocaleLowerCase() === "tags"
+						? "Use a tag filter for tags."
+						: "That is an internal metadata field and cannot be filtered.",
+				);
+				return;
+			}
+			const parsed = this.selectedValue
+				? { valid: true, value: this.selectedValue.value }
+				: parseValueInput(this.valueInput.value);
+			if (!property || !parsed.valid || parsed.value === undefined) return;
+			rule = { kind: "property", mode: this.mode, property, value: parsed.value };
+		}
+
+		if (this.plugin.settings.filterRules.some((current) => sameFilterRule(current, rule))) {
+			new Notice("That journal filter already exists.");
+			return;
+		}
+		this.plugin.settings.filterRules = [...this.plugin.settings.filterRules, rule];
+		this.tagInput.value = "";
+		this.propertyInput.value = "";
+		this.valueInput.value = "";
+		this.selectedValue = null;
+		this.renderRules();
+		this.syncAddButton();
+		this.persist();
+	}
+
+	private removeRule(index: number): void {
+		this.plugin.settings.filterRules = this.plugin.settings.filterRules.filter(
+			(_rule, current) => current !== index,
+		);
+		this.renderRules();
+		this.persist();
+	}
+
+	private renderRules(): void {
+		this.listEl.empty();
+		const rules = this.plugin.settings.filterRules;
+		if (!rules.length) {
+			this.listEl.createDiv({
+				cls: "setting-item-description journal-filter-empty",
+				text: "No tag or property filters.",
+			});
+			return;
+		}
+		rules.forEach((rule, index) => {
+			new Setting(this.listEl).setName(ruleLabel(rule)).addExtraButton((button) =>
+				button.setIcon("x").setTooltip("Remove filter").onClick(() => this.removeRule(index)),
+			);
+		});
+	}
+
+	private persist(): void {
+		this.plugin.notifyFiltersImmediately();
+		this.saving = this.saving
+			.then(() => this.plugin.saveSettings(false))
+			.catch((error: unknown) => {
+				console.error("Journal View: could not save filters", error);
+				new Notice("Journal view: could not save filters");
+			});
+	}
+}

--- a/src/find.ts
+++ b/src/find.ts
@@ -153,6 +153,10 @@ export class JournalFind {
 		this.matches = [];
 
 		for (const [sectionIndex, section] of this.host.sections.entries()) {
+			if (section.isHidden) {
+				section.setFindState(query, this.caseSensitive, [], null);
+				continue;
+			}
 			const ranges = findLiteralRanges(section.searchText(), query, this.caseSensitive);
 			section.setFindState(query, this.caseSensitive, ranges, null);
 			for (const range of ranges) this.matches.push({ section, sectionIndex, key: section.key, ...range });
@@ -233,7 +237,8 @@ export class JournalFind {
 		const loadedKeys = new Set(this.host.sections.map((section) => section.key));
 		const edge = direction > 0 ? this.host.sections[this.host.sections.length - 1].key : this.host.sections[0].key;
 		const dateDirection = (direction * this.host.sortStep()) as -1 | 1;
-		const keys = this.host.plugin.index.keysFrom(edge, dateDirection);
+		this.host.plugin.filteredIndex.ensureCurrent();
+		const keys = this.host.plugin.filteredIndex.keysFrom(edge, dateDirection);
 		const today = createMoment().startOf("day");
 
 		try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { MarkdownView, Plugin, TFile, WorkspaceLeaf, debounce } from "obsidian";
 import { DailyNoteResolver } from "./dailyNotes";
 import { WorkspaceEditorBridge } from "./editor";
+import { FilteredDailyNoteIndex, filterRulesSetting } from "./filter";
 import { createMoment } from "./moment";
 import type { Moment } from "./moment";
 import { DAY_KEY_FORMAT, DailyNoteIndex } from "./noteIndex";
@@ -20,8 +21,11 @@ export default class JournalViewPlugin extends Plugin {
 	settings: JournalViewSettings = { ...DEFAULT_SETTINGS };
 	daily!: DailyNoteResolver;
 	index!: DailyNoteIndex;
+	filteredIndex!: FilteredDailyNoteIndex;
 	readonly workspaceEditors = new WorkspaceEditorBridge(this.app);
 	private dailyNoteActions = new Map<MarkdownView, HTMLElement>();
+	private settingsTab: JournalViewSettingTab | null = null;
+	private filterControlListeners = new Set<() => void>();
 	/** Target dates handed to journal views before Obsidian constructs them. */
 	private initialDates = new Map<WorkspaceLeaf, Moment>();
 
@@ -43,32 +47,62 @@ export default class JournalViewPlugin extends Plugin {
 		this.updateViews();
 	}
 
+	/** Refreshes metadata filtering before open views read the new rule set. */
+	notifyFiltersImmediately(): void {
+		this.filteredIndex.ensureCurrent();
+		this.syncFilterControls();
+		this.updateViews();
+	}
+
+	/** Keeps the modal and settings-tab copies of the note-only toggle in sync. */
+	onFilterControlsChanged(listener: () => void): () => void {
+		this.filterControlListeners.add(listener);
+		return () => this.filterControlListeners.delete(listener);
+	}
+
+	private syncFilterControls(): void {
+		this.settingsTab?.syncFilterControls();
+		for (const listener of this.filterControlListeners) listener();
+	}
+
 	async onload(): Promise<void> {
 		await this.loadSettings();
 		this.daily = new DailyNoteResolver(this.app, () => this.settings);
 		this.index = new DailyNoteIndex(this.app, this.daily);
+		this.filteredIndex = new FilteredDailyNoteIndex(this.app, this.index, () => this.settings.filterRules);
 
 		// The index has to be registered before any view, so it is already up to
 		// date by the time a view reacts to the same vault event.
 		this.app.workspace.onLayoutReady(() => {
 			this.index.rebuild();
+			this.filteredIndex.rebuild();
 			this.syncDailyNoteActions();
 		});
 		this.registerEvent(
 			this.app.vault.on("create", (file) => {
-				if (file instanceof TFile) this.index.handleCreate(file);
+				if (file instanceof TFile) {
+					this.index.handleCreate(file);
+					this.filteredIndex.ensureCurrent();
+				}
 			}),
 		);
 		this.registerEvent(
 			this.app.vault.on("delete", (file) => {
 				this.index.handleDelete(file.path);
+				this.filteredIndex.ensureCurrent();
 			}),
 		);
 		this.registerEvent(
 			this.app.vault.on("rename", (file, oldPath) => {
 				this.index.handleDelete(oldPath);
 				if (file instanceof TFile) this.index.handleCreate(file);
+				this.filteredIndex.ensureCurrent();
 				this.syncDailyNoteActions();
+			}),
+		);
+		this.registerEvent(
+			this.app.metadataCache.on("changed", (file) => {
+				this.filteredIndex.handleMetadataChange(file);
 			}),
 		);
 		this.registerEvent(this.app.workspace.on("file-open", () => this.syncDailyNoteActions()));
@@ -105,7 +139,8 @@ export default class JournalViewPlugin extends Plugin {
 			},
 		});
 
-		this.addSettingTab(new JournalViewSettingTab(this.app, this));
+		this.settingsTab = new JournalViewSettingTab(this.app, this);
+		this.addSettingTab(this.settingsTab);
 	}
 
 	onunload(): void {
@@ -199,7 +234,7 @@ export default class JournalViewPlugin extends Plugin {
 	async loadSettings(): Promise<void> {
 		const saved: unknown = await this.loadData();
 		if (!isRecord(saved)) {
-			this.settings = { ...DEFAULT_SETTINGS, displayProperties: [] };
+			this.settings = { ...DEFAULT_SETTINGS, filterRules: [], displayProperties: [] };
 			return;
 		}
 		this.settings = {
@@ -220,6 +255,7 @@ export default class JournalViewPlugin extends Plugin {
 			richEditor: booleanSetting(saved.richEditor, DEFAULT_SETTINGS.richEditor),
 			focusTodayOnOpen: booleanSetting(saved.focusTodayOnOpen, DEFAULT_SETTINGS.focusTodayOnOpen),
 			hideEmptyDays: booleanSetting(saved.hideEmptyDays, DEFAULT_SETTINGS.hideEmptyDays),
+			filterRules: filterRulesSetting(saved.filterRules),
 			showTags: booleanSetting(saved.showTags, DEFAULT_SETTINGS.showTags),
 			displayProperties: propertyNamesSetting(saved.displayProperties),
 			daySortDirection: daySortDirectionSetting(saved.daySortDirection),
@@ -227,7 +263,9 @@ export default class JournalViewPlugin extends Plugin {
 	}
 
 	async saveSettings(scheduleViewUpdate = true): Promise<void> {
+		this.syncFilterControls();
 		await this.saveData(this.settings);
+		this.filteredIndex?.ensureCurrent();
 		this.syncDailyNoteActions();
 		if (scheduleViewUpdate) this.notifyViews();
 	}

--- a/src/noteIndex.ts
+++ b/src/noteIndex.ts
@@ -4,13 +4,24 @@ import { createMoment } from "./moment";
 
 export const DAY_KEY_FORMAT = "YYYY-MM-DD";
 
+/** Chronologically ordered set of daily-note keys used by walkers and navigation. */
+export interface OrderedDayIndex {
+	readonly version: number;
+	has(key: string): boolean;
+	readonly size: number;
+	range(): { first: string; last: string } | null;
+	next(key: string): string | null;
+	prev(key: string): string | null;
+	keysFrom(key: string, direction: -1 | 1): string[];
+}
+
 /**
  * Knows which days actually have a note, so the view can jump straight from one
  * existing day to the next instead of walking the calendar one day at a time.
  *
  * Keys are `YYYY-MM-DD`, which sorts chronologically as plain strings.
  */
-export class DailyNoteIndex {
+export class DailyNoteIndex implements OrderedDayIndex {
 	private keys = new Set<string>();
 	private sorted: string[] = [];
 	private sortedDirty = true;
@@ -39,6 +50,11 @@ export class DailyNoteIndex {
 	/** Rebuilds only if the daily-note configuration moved since the last scan. */
 	ensureCurrent(): void {
 		if (JSON.stringify(this.resolver.config()) !== this.signature) this.rebuild();
+	}
+
+	/** One resolved configuration for callers scanning more than one path. */
+	resolvedConfig(): ResolvedDailyConfig {
+		return this.resolver.config();
 	}
 
 	/** The day a path represents, or null if it is not a daily note. */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { App, PluginSettingTab, Setting, requireApiVersion } from "obsidian";
-import type { SettingDefinitionItem } from "obsidian";
+import type { SettingDefinitionItem, ToggleComponent } from "obsidian";
 import type JournalViewPlugin from "./main";
 
 export const MIN_SAVE_DELAY = 200;
@@ -12,6 +12,17 @@ export const MONTH_SEPARATOR_DAY_FORMAT = "dddd, D";
 export const LEGACY_FULL_HEADER_FORMAT = "dddd, D MMMM YYYY";
 
 export type DaySortDirection = "ascending" | "descending";
+export type JournalFilterMode = "include" | "exclude";
+export type JournalFilterValue = string | number | boolean;
+
+export type JournalFilterRule =
+	| { kind: "tag"; mode: JournalFilterMode; tag: string }
+	| {
+			kind: "property";
+			mode: JournalFilterMode;
+			property: string;
+			value: JournalFilterValue;
+	  };
 
 export interface JournalViewSettings {
 	/** Overrides the daily-note date format. Empty = inherit from the vault. */
@@ -36,6 +47,8 @@ export interface JournalViewSettings {
 	focusTodayOnOpen: boolean;
 	/** Show only days that have a note (today always shows). */
 	hideEmptyDays: boolean;
+	/** Tag and property rules that decide which existing notes are visible. */
+	filterRules: JournalFilterRule[];
 	/** Show frontmatter tags above each existing note's body. */
 	showTags: boolean;
 	/** Frontmatter property names shown above each existing note's body. */
@@ -58,6 +71,7 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	richEditor: true,
 	focusTodayOnOpen: true,
 	hideEmptyDays: true,
+	filterRules: [],
 	showTags: false,
 	displayProperties: [],
 	daySortDirection: "ascending",
@@ -126,6 +140,8 @@ interface LegacySliderTooltip {
 }
 
 export class JournalViewSettingTab extends PluginSettingTab {
+	private hideEmptyToggle: ToggleComponent | null = null;
+
 	constructor(app: App, private plugin: JournalViewPlugin) {
 		super(app, plugin);
 	}
@@ -311,6 +327,7 @@ export class JournalViewSettingTab extends PluginSettingTab {
 
 	display(): void {
 		const { containerEl } = this;
+		this.hideEmptyToggle = null;
 		containerEl.empty();
 		for (const group of this.definitions()) {
 			new Setting(containerEl).setName(group.heading).setHeading();
@@ -339,11 +356,12 @@ export class JournalViewSettingTab extends PluginSettingTab {
 				);
 				break;
 			case "toggle":
-				setting.addToggle((toggle) =>
+				setting.addToggle((toggle) => {
+					if (control.key === "hideEmptyDays") this.hideEmptyToggle = toggle;
 					toggle
 						.setValue(this.plugin.settings[control.key])
-						.onChange((value) => this.setControlValue(control.key, value)),
-				);
+						.onChange((value) => this.setControlValue(control.key, value));
+				});
 				break;
 			case "slider":
 				setting.addSlider((slider) => {
@@ -363,6 +381,10 @@ export class JournalViewSettingTab extends PluginSettingTab {
 				);
 				break;
 		}
+	}
+
+	syncFilterControls(): void {
+		this.hideEmptyToggle?.setValue(this.plugin.settings.hideEmptyDays);
 	}
 }
 

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -15,7 +15,7 @@ function applyIcon(el: HTMLElement, ...names: string[]): void {
 
 /** What the toolbar's controls ask the view to do. */
 export interface ToolbarActions {
-	onToggleFilter(): void;
+	onShowFilter(): void;
 	onShowAppearance(): void;
 	onShowFind(): void;
 	onGoToDate(): void;
@@ -51,9 +51,11 @@ export class JournalToolbar {
 			this.buttons.push(appearanceButton);
 
 			this.filterButton = buttons.createEl("button", {
-				cls: "clickable-icon journal-toolbar-button",
+				cls: "clickable-icon journal-toolbar-button journal-filter-button",
+				attr: { "aria-haspopup": "dialog" },
 			});
-			this.filterButton.addEventListener("click", () => actions.onToggleFilter());
+			applyIcon(this.filterButton, "filter");
+			this.filterButton.addEventListener("click", () => actions.onShowFilter());
 			this.buttons.push(this.filterButton);
 
 			const findButton = buttons.createEl("button", {
@@ -104,8 +106,10 @@ export class JournalToolbar {
 		setTooltip(findButton, "Find in journal");
 		this.buttons.push(findButton);
 
-		this.filterButton = view.addAction("filter", "Filter days", () => actions.onToggleFilter());
-		this.filterButton.addClass("journal-toolbar-button");
+		this.filterButton = view.addAction("filter", "Filter notes", () => actions.onShowFilter());
+		this.filterButton.addClasses(["journal-toolbar-button", "journal-filter-button"]);
+		applyIcon(this.filterButton, "filter");
+		this.filterButton.setAttribute("aria-haspopup", "dialog");
 		const appearanceButton = view.addAction("settings-2", "Customization", () => actions.onShowAppearance());
 		appearanceButton.addClass("journal-toolbar-button");
 		applyIcon(appearanceButton, "settings-2", "settings");
@@ -126,11 +130,11 @@ export class JournalToolbar {
 		if (this.labelEl.getText() !== text) this.labelEl.setText(text);
 	}
 
-	setFilter(on: boolean): void {
-		applyIcon(this.filterButton, on ? "filter" : "filter-x", "filter");
-		setTooltip(this.filterButton, on ? "Showing only days with notes" : "Showing every day");
-		this.filterButton.toggleClass("is-active", on);
-		this.filterButton.setAttribute("aria-pressed", String(on));
+	setFilter(active: boolean): void {
+		applyIcon(this.filterButton, "filter");
+		setTooltip(this.filterButton, active ? "Filter notes (filters active)" : "Filter notes");
+		this.filterButton.toggleClass("is-active", active);
+		this.filterButton.removeAttribute("aria-pressed");
 	}
 
 	setVisible(visible: boolean): void {

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,8 +1,10 @@
-import { ItemView, Scope, TAbstractFile, TFile, WorkspaceLeaf } from "obsidian";
+import { ItemView, Notice, Scope, TAbstractFile, TFile, WorkspaceLeaf } from "obsidian";
 import type JournalViewPlugin from "./main";
 import { AnchorHost, START_GUTTER, ScrollAnchor } from "./anchor";
 import { AppearanceModal } from "./appearance";
 import { DatePickerModal } from "./datePicker";
+import { FilterModal } from "./filterModal";
+import { isFilterActive } from "./filter";
 import { DayHost, DaySection } from "./day";
 import { DayWalker, isOffsetReachable } from "./dayWalk";
 import { EditorWindow, EditorWindowHost } from "./editorWindow";
@@ -65,18 +67,14 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private picker: DatePickerModal | null = null;
 	/** Appearance settings owned by this view while its modal is open. */
 	private appearance: AppearanceModal | null = null;
+	/** Filter settings owned by this view while its modal is open. */
+	private filterModal: FilterModal | null = null;
 	private readonly anchoring = new ScrollAnchor(this);
 	private readonly editors = new EditorWindow(this);
 	private walker!: DayWalker;
 
 	private byPath = new Map<string, DaySection>();
 	private today: Moment = createMoment().startOf("day");
-	/**
-	 * A day the reader went to by date. It stays in the journal even with empty
-	 * days hidden - being asked for by name is reason enough to show a day.
-	 */
-	private visited: Moment | null = null;
-
 	private resizeObserver: ResizeObserver | null = null;
 	private scrollFrame = 0;
 	private animFrame = 0;
@@ -118,6 +116,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private appliedMaxLoadedDays = 0;
 	private configSignature = "";
 	private indexVersion = -1;
+	private filteredIndexVersion = -1;
 	private initialDate?: Moment;
 
 	constructor(
@@ -167,7 +166,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.contentEl.addClass("journal-content");
 
 		this.toolbar = new JournalToolbar(this, {
-			onToggleFilter: () => void this.toggleHideEmptyDays(),
+			onShowFilter: () => this.openFilter(),
 			onShowAppearance: () => this.openAppearance(),
 			onShowFind: () => this.showFind(),
 			onGoToDate: () => this.openDatePicker(),
@@ -187,9 +186,12 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.registerDomEvent(this.containerEl, "keydown", (event) => this.onKeydown(event), { capture: true });
 		this.registerVaultEvents();
 
-		const initialDate = this.initialDate;
+		let initialDate = this.initialDate;
 		this.initialDate = undefined;
-		if (initialDate) this.visited = initialDate.clone().startOf("day");
+		if (initialDate && !this.isDateVisible(initialDate)) {
+			initialDate = undefined;
+			new Notice("That day is hidden by the current journal filters. Showing today instead.");
+		}
 		await this.build(initialDate, !initialDate);
 		if (initialDate) this.focusOriginWhenReady();
 	}
@@ -198,6 +200,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		// Modals hold this view in their callbacks, so they have to go with it.
 		this.picker?.close();
 		this.appearance?.close();
+		this.filterModal?.close();
 		this.find?.destroy();
 		this.find = undefined;
 		this.toolbar?.destroy();
@@ -247,12 +250,14 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.today = createMoment().startOf("day");
 		this.configSignature = JSON.stringify(this.plugin.daily.config());
 		this.plugin.index.ensureCurrent();
+		this.plugin.filteredIndex.ensureCurrent();
 		this.indexVersion = this.plugin.index.version;
+		this.filteredIndexVersion = this.plugin.filteredIndex.version;
 		this.walker = new DayWalker(
 			this.today,
 			this.plugin.index,
+			this.plugin.filteredIndex,
 			() => this.plugin.settings.hideEmptyDays,
-			this.visited ?? undefined,
 		);
 		this.exhausted = { start: false, end: false };
 		this.loading = { start: false, end: false };
@@ -362,6 +367,18 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	private createSection(offset: number): DaySection {
 		return new DaySection(this, this.walker.dateFor(offset), offset);
+	}
+
+	/** Shared visibility predicate for the timeline, calendar and direct navigation. */
+	private isDateVisible(date: Moment): boolean {
+		const day = date.clone().startOf("day");
+		if (day.isSame(createMoment().startOf("day"), "day")) return true;
+		this.plugin.index.ensureCurrent();
+		this.plugin.filteredIndex.ensureCurrent();
+		const key = day.format("YYYY-MM-DD");
+		return this.plugin.index.has(key)
+			? this.plugin.filteredIndex.has(key)
+			: !this.plugin.settings.hideEmptyDays;
 	}
 
 	/** Date offset step made by moving down through the rendered timeline. */
@@ -909,17 +926,6 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	goToToday(focus = false): void {
 		const now = createMoment().startOf("day");
-		// Coming home also gives up the day the reader went to by date; today
-		// is pinned in its own right.
-		const droppedVisited = this.visited !== null && !this.visited.isSame(now, "day");
-		this.visited = null;
-		if (droppedVisited && this.plugin.settings.hideEmptyDays) {
-			void this.rebuild().then(() => {
-				const section = this.sectionAt(0);
-				if (focus && section) this.focusAfterCenter(section, true);
-			});
-			return;
-		}
 		const section = this.sectionAt(0);
 		if (!now.isSame(this.today, "day") || !section) {
 			// Midnight has passed, or today was trimmed away after a long
@@ -940,12 +946,14 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		// The dots come straight from the index, so it has to agree with the
 		// vault's current daily-note configuration before any of them are drawn.
 		this.plugin.index.ensureCurrent();
+		this.plugin.filteredIndex.ensureCurrent();
 		this.picker?.close();
 		const picker = new DatePickerModal(this.app, {
-			index: this.plugin.index,
+			index: this.plugin.filteredIndex,
 			today: createMoment().startOf("day"),
 			current: this.visibleDate(),
 			allowDistantNotes: this.plugin.settings.hideEmptyDays,
+			isVisible: (date) => this.isDateVisible(date),
 			onPick: (date) => this.goToDate(date),
 			onDismiss: () => {
 				if (this.picker === picker) this.picker = null;
@@ -953,6 +961,18 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		});
 		this.picker = picker;
 		picker.open();
+	}
+
+	/** Opens the global journal visibility controls. */
+	private openFilter(): void {
+		this.filterModal?.close();
+		const filterModal = new FilterModal(this.app, this.plugin, {
+			onDismiss: () => {
+				if (this.filterModal === filterModal) this.filterModal = null;
+			},
+		});
+		this.filterModal = filterModal;
+		filterModal.open();
 	}
 
 	/** Opens the global metadata display controls. */
@@ -968,10 +988,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	/**
-	 * Moves the journal to `date`. A day already in the window is scrolled to;
-	 * anything further away is a rebuild around that day. A day with no note is
-	 * shown either way, empty days hidden or not - it is where the reader asked
-	 * to be, and it is where they would start writing.
+	 * Moves the journal to a visible `date`. The same predicate is used by every
+	 * caller so direct navigation cannot temporarily reveal a filtered note.
 	 */
 	goToDate(date: Moment, focus = true): void {
 		// A date can arrive from a picker that outlived the view it was opened
@@ -982,11 +1000,14 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		window.clearTimeout(this.initialFocusTimer);
 		this.initialFocusTimer = 0;
 		const day = date.clone().startOf("day");
+		if (!this.isDateVisible(day)) {
+			new Notice("That day is hidden by the current journal filters. Showing today instead.");
+			this.goToToday(focus);
+			return;
+		}
 		const offset = day.diff(this.today, "days");
-		const indexed = this.plugin.index.has(this.walker.keyFor(offset));
+		const indexed = this.plugin.filteredIndex.has(this.walker.keyFor(offset));
 		if (!isOffsetReachable(offset, this.plugin.settings.hideEmptyDays, indexed)) return;
-		const changedVisited = !this.visited?.isSame(day, "day");
-		this.visited = day;
 		// A view built while hidden has not committed to a scroll position yet.
 		// Rebuild around the requested day so its first measurable resize cannot
 		// centre the old origin over this navigation.
@@ -996,14 +1017,6 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			});
 			return;
 		}
-		if (changedVisited && this.plugin.settings.hideEmptyDays) {
-			void this.rebuild(day).then(() => {
-				const section = this.sectionAt(this.origin);
-				if (focus && section) this.focusAfterCenter(section, false);
-			});
-			return;
-		}
-
 		const section = createMoment().startOf("day").isSame(this.today, "day") ? this.sectionAt(offset) : undefined;
 		if (section) {
 			// Focusing only once the animation has arrived: focus scrolls the
@@ -1055,7 +1068,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.registerEvent(
 			this.app.vault.on("delete", (file) => {
 				this.syncWithIndex();
-				const section = this.byPath.get(file.path);
+				let section = this.byPath.get(file.path);
+				if (!section) section = this.ensureVisiblePath(file.path);
 				if (!section || section.file?.path !== file.path) return;
 				this.byPath.delete(file.path);
 				section.setFile(null);
@@ -1070,6 +1084,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 					this.byPath.delete(oldPath);
 					previous.setFile(null);
 				}
+				if (!previous) this.ensureVisiblePath(oldPath);
 				if (file instanceof TFile) this.attachFile(file);
 				else this.syncWithIndex();
 			}),
@@ -1077,8 +1092,19 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 		this.registerEvent(
 			this.app.metadataCache.on("changed", (file, data) => {
-				const section = this.byPath.get(file.path);
-				if (section?.file?.path === file.path) void section.reload(data);
+				const indexChanged = this.syncWithIndex();
+				let section = this.byPath.get(file.path);
+				if (!section && indexChanged) {
+					const key = this.plugin.index.keyForPath(file.path);
+					if (key && this.plugin.filteredIndex.has(key)) {
+						section = this.ensureSectionFor(this.walker.offsetFor(key));
+					}
+				}
+				if (section?.file?.path === file.path) {
+					section.refreshState();
+					this.syncDateSeparators();
+					void section.reload(data);
+				}
 			}),
 		);
 
@@ -1108,7 +1134,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			// A note can appear for a day the view skipped over (sync, another
 			// window, "hide empty days" turned on). Slot it into place.
 			const key = this.plugin.index.keyForPath(file.path);
-			section = key ? this.ensureSectionFor(this.walker.offsetFor(key)) : undefined;
+			const offset = key ? this.walker.offsetFor(key) : null;
+			section = offset !== null && this.walker.isVisible(offset) ? this.ensureSectionFor(offset) : undefined;
 		}
 		if (!section || section.file?.path === file.path) return;
 		if (section.path !== file.path) return;
@@ -1116,14 +1143,27 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		void section.reload();
 	}
 
+	/** Restores a date that became an empty, visible day after a delete or rename. */
+	private ensureVisiblePath(path: string): DaySection | undefined {
+		const key = this.plugin.index.keyForPath(path);
+		if (!key) return undefined;
+		const offset = this.walker.offsetFor(key);
+		return this.walker.isVisible(offset) ? this.ensureSectionFor(offset) : undefined;
+	}
+
 	/**
 	 * A day appearing or disappearing can un-exhaust an end of the journal, so
 	 * loading is allowed to try again.
 	 */
-	private syncWithIndex(): void {
-		if (this.plugin.index.version === this.indexVersion) return;
+	private syncWithIndex(): boolean {
+		const changed =
+			this.plugin.index.version !== this.indexVersion ||
+			this.plugin.filteredIndex.version !== this.filteredIndexVersion;
+		if (!changed) return false;
 		this.indexVersion = this.plugin.index.version;
+		this.filteredIndexVersion = this.plugin.filteredIndex.version;
 		this.exhausted = { start: false, end: false };
+		return true;
 	}
 
 	/** Materialises a day that falls inside the range already rendered. */
@@ -1154,13 +1194,12 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		return section;
 	}
 
-	/**
-	 * Today, and a day the reader went to by date, are the journal's own days
-	 * rather than the index's - the walker decides which, so a day it built
-	 * against the filter is not then hidden by the day itself.
-	 */
-	isPinnedDay(day: DaySection): boolean {
-		return this.walker ? this.walker.isPinned(day.offset) : day.offset === 0;
+	/** Keeps each rendered section aligned with the walker's visibility rules. */
+	isVisibleDay(day: DaySection): boolean {
+		// A focused editor is a transient display guard, not index membership: it
+		// prevents an autosave from dismissing the day underneath the reader while
+		// navigation and future visits remain strictly filtered.
+		return day.hasFocus || (this.walker ? this.walker.isVisible(day.offset) : day.offset === 0);
 	}
 
 	onDayFileChanged(day: DaySection, previousPath: string | null): void {
@@ -1171,6 +1210,15 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	onDayContentChanged(_day: DaySection): void {
+		this.find?.sectionsChanged();
+	}
+
+	onDayFocusChanged(day: DaySection): void {
+		if (!day.el.isConnected) return;
+		const wasHidden = day.isHidden;
+		day.refreshVisibility();
+		if (day.isHidden === wasHidden) return;
+		this.syncDateSeparators();
 		this.find?.sectionsChanged();
 	}
 
@@ -1196,6 +1244,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		if (signature === this.configSignature) return;
 		this.configSignature = signature;
 		this.plugin.index.ensureCurrent();
+		this.plugin.filteredIndex.ensureCurrent();
 		this.syncWithIndex();
 
 		let changed = false;
@@ -1210,19 +1259,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	/* ------------------------------------------------------------ settings */
 
-	/**
-	 * Flips the same setting the settings tab owns, so every open journal - and
-	 * the tab itself, next time it is drawn - follows along.
-	 */
-	private async toggleHideEmptyDays(): Promise<void> {
-		this.plugin.settings.hideEmptyDays = !this.plugin.settings.hideEmptyDays;
-		this.syncFilterButton();
-		await this.plugin.saveSettings();
-	}
-
 	private syncFilterButton(): void {
 		// Settings can be saved from elsewhere before this view has a toolbar.
-		this.toolbar?.setFilter(this.plugin.settings.hideEmptyDays);
+		this.toolbar?.setFilter(isFilterActive(this.plugin.settings));
 	}
 
 	/** Settings whose existing day DOM cannot adopt safely in place. */
@@ -1237,11 +1276,14 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			groupDaysByYear: settings.groupDaysByYear,
 			richEditor: settings.richEditor,
 			hideEmptyDays: settings.hideEmptyDays,
+			filterRules: settings.filterRules,
 			daySortDirection: settings.daySortDirection,
 		});
 	}
 
 	async onSettingsChanged(): Promise<void> {
+		this.plugin.filteredIndex.ensureCurrent();
+		this.syncWithIndex();
 		this.syncFilterButton();
 		if (!this.ready) {
 			// A build is in flight against the old values - dropping the change

--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,11 @@
 	padding-inline: var(--size-4-2);
 }
 
+button.journal-filter-button.is-active,
+.journal-filter-button.is-active {
+	color: var(--text-accent);
+}
+
 /* ----------------------------------------------------------- find bar --- */
 
 .journal-find-bar {
@@ -1075,6 +1080,102 @@ button.journal-appearance-settings-link {
 button.journal-appearance-settings-link:hover {
 	background-color: var(--background-modifier-border);
 	color: var(--text-normal);
+}
+
+/* --------------------------------------------------------- filter modal -- */
+
+.journal-filter-modal {
+	width: min(680px, 94vw);
+}
+
+.journal-filter-modal .modal-content {
+	margin-top: var(--size-4-2);
+}
+
+.modal.journal-filter-modal .journal-filter-metadata-heading.setting-item {
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.modal.journal-filter-modal .journal-filter-add.setting-item {
+	align-items: flex-start;
+	border-top: 0;
+}
+
+.journal-filter-add .setting-item-control {
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: flex-end;
+	min-width: 0;
+	gap: var(--size-2-2);
+}
+
+.journal-filter-add select,
+.journal-filter-add button {
+	flex: 0 0 auto;
+	width: auto;
+}
+
+.journal-filter-add input[type="text"] {
+	flex: 1 1 11rem;
+	min-width: 0;
+	width: min(11rem, 28vw);
+	max-width: 11rem;
+	box-sizing: border-box;
+}
+
+.journal-filter-add.is-property input[type="text"] {
+	flex-basis: 8rem;
+	width: min(8rem, 20vw);
+	max-width: 8rem;
+}
+
+.journal-filter-add input[hidden] {
+	display: none;
+}
+
+.journal-filter-rules {
+	margin-top: var(--size-4-2);
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.modal.journal-filter-modal .journal-filter-rules > .setting-item:first-child {
+	border-top: 0;
+	padding-top: var(--size-4-3);
+}
+
+.modal.journal-filter-modal .journal-filter-rules > .setting-item {
+	align-items: center;
+	min-height: 0;
+	padding-top: var(--size-2-3);
+	padding-bottom: var(--size-2-3);
+}
+
+.modal.journal-filter-modal .journal-filter-rules > .setting-item > .setting-item-info,
+.modal.journal-filter-modal .journal-filter-rules > .setting-item > .setting-item-control {
+	align-self: center;
+}
+
+.journal-filter-empty {
+	padding: var(--size-4-3) 0;
+}
+
+@media (max-width: 520px) {
+	.modal.journal-filter-modal .journal-filter-add.setting-item {
+		display: block;
+	}
+
+	.journal-filter-add .setting-item-control {
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		margin-top: var(--size-4-2);
+	}
+
+	.journal-filter-add input[type="text"],
+	.journal-filter-add.is-property input[type="text"] {
+		width: min(100%, 13rem);
+		max-width: none;
+		flex: 1 1 9rem;
+	}
 }
 
 /* -------------------------------------------------------------- settings -- */


### PR DESCRIPTION
## Summary

- replace the toolbar toggle with a Filter notes modal
- add persisted include and exclude rules for tags and typed frontmatter properties
- apply the same visibility rules to the journal timeline, Go to date, and journal-wide Find
- keep Today available and protect focused editors from being hidden during autosave
- document filter matching and navigation behavior

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test-vault` prepared the throwaway vault; live Obsidian interaction was not run because Obsidian was not running
