### PR TITLE
Fix post-release lint warnings

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -278,12 +278,12 @@ function publishWorkspaceContent(app: App, owner: ActiveEditorOwner, content: st
 
 		const internalPlugins = app.internalPlugins as unknown as InternalPluginHost | undefined;
 		const plugin = internalPlugins?.getPluginById("word-count");
-		const onQuickPreview = plugin?.instance?.onQuickPreview;
-		if (!plugin?.enabled || typeof onQuickPreview !== "function") return;
+		const instance = plugin?.instance;
+		if (!plugin?.enabled || typeof instance?.onQuickPreview !== "function") return;
 		plugin.statusBarEl?.toggle?.(true);
 		// The handler strips frontmatter and Markdown syntax before counting. Its
 		// file argument is only an identity check against the current active file.
-		onQuickPreview.call(plugin.instance, workspace.getActiveFile(), content);
+		instance.onQuickPreview(workspace.getActiveFile(), content);
 	} catch (error) {
 		console.warn("Journal View: could not publish the active editor content", error);
 	}

--- a/styles.css
+++ b/styles.css
@@ -418,8 +418,7 @@ button.journal-day-create:hover {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
-	column-gap: var(--size-2-3);
-	row-gap: var(--size-2-2);
+	gap: var(--size-2-2) var(--size-2-3);
 	/* Match the header's bottom margin so the strip has the same breathing
 	   room above and below it. */
 	margin: 0 0 var(--size-2-3);


### PR DESCRIPTION
## Summary

- Keep the internal Word Count plugin instance as the receiver when publishing unsaved editor content, avoiding the unbound-method warning without changing behavior.
- Express metadata row and column spacing with the flexbox `gap` shorthand, preserving the layout while avoiding the externally reported, partially supported multicolumn feature warning.

## Verification

- `npm run lint` (covers the TypeScript unbound-method warning)
- `npm run typecheck`
- `npm run build`
- Reloaded the plugin in the throwaway Obsidian vault and inspected metadata strips containing both a displayed property and tags; the layout rendered normally, with computed `row-gap: 4px` and `column-gap: 6px`.

The repository has no CSS lint command, so the externally reported CSS compatibility warning is not reproducible through `npm run lint`; the flagged `column-gap` declaration has been removed.