### PR TITLE
Make the daily-note open control configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Some Customization is only visible in the customization menu accessible from the
 | Day order | Oldest to newest | Reverses the complete timeline when set to newest to oldest |
 | Daily header format | `dddd, D MMMM` | Controls how each daily header displays its date |
 | Daily header style | Subtle | Shows each date subtly, as an H1, or hides the date display |
+| Open note control | Show button | Can hide the open-note button or replace it with a clickable daily heading |
 | Group days by year | On | Marks year boundaries between consecutive visible daily entries |
 | Group days by month | Off | Groups daily entries beneath compact month and year headings |
 | Focus today on open | On | Opens the journal at today's note and places the cursor there |

--- a/src/day.ts
+++ b/src/day.ts
@@ -404,8 +404,32 @@ export class DaySection {
 				if (!this.destroyed && !this.hasFocus) this.host.onDayFocusChanged(this);
 			}, 0);
 		});
+		this.titleEl.addEventListener("click", (event) => this.onTitleClick(event));
+		this.titleEl.addEventListener("keydown", (event) => this.onTitleKeydown(event));
 
 		this.refreshState();
+	}
+
+	private onTitleClick(event: MouseEvent): void {
+		if (!this.canOpenFromTitle()) return;
+		event.preventDefault();
+		event.stopPropagation();
+		void this.openInTab(event.ctrlKey || event.metaKey);
+	}
+
+	private onTitleKeydown(event: KeyboardEvent): void {
+		if (event.key !== "Enter" || !this.canOpenFromTitle()) return;
+		event.preventDefault();
+		event.stopPropagation();
+		void this.openInTab(event.ctrlKey || event.metaKey);
+	}
+
+	private canOpenFromTitle(): boolean {
+		return (
+			this.exists &&
+			this.host.plugin.settings.openNoteAction === "heading" &&
+			this.host.plugin.settings.headerStyle !== "hidden"
+		);
 	}
 
 	private onClick(event: MouseEvent): void {
@@ -576,7 +600,7 @@ export class DaySection {
 
 		this.bodyEl.dataset.placeholder = this.exists ? "Empty note" : "Start typing to create this note";
 		this.actionsEl.empty();
-		setTooltip(this.titleEl, this.path, { placement: "right" });
+		this.syncHeaderSettings();
 
 		if (this.exists) {
 			const remove = this.actionsEl.createEl("button", {
@@ -589,7 +613,9 @@ export class DaySection {
 				void this.deleteNote();
 			});
 
-			const open = this.actionsEl.createEl("button", { cls: "clickable-icon journal-day-action" });
+			const open = this.actionsEl.createEl("button", {
+				cls: "clickable-icon journal-day-action journal-day-open",
+			});
 			setIcon(open, "file-text");
 			setTooltip(open, "Open note in a tab");
 			open.addEventListener("click", (event) => {
@@ -1368,6 +1394,20 @@ export class DaySection {
 			tags.push(tag);
 		}
 		return tags;
+	}
+
+	syncHeaderSettings(): void {
+		const clickable = this.canOpenFromTitle();
+		this.titleEl.toggleClass("journal-day-title-clickable", clickable);
+		if (clickable) {
+			this.titleEl.setAttribute("role", "link");
+			this.titleEl.setAttribute("tabindex", "0");
+			setTooltip(this.titleEl, `Open note: ${this.path}`, { placement: "right" });
+			return;
+		}
+		this.titleEl.removeAttribute("role");
+		this.titleEl.removeAttribute("tabindex");
+		setTooltip(this.titleEl, this.path, { placement: "right" });
 	}
 
 	private async deleteNote(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import {
 	clampLoadedDays,
 	clampSaveDelay,
 } from "./settings";
-import type { DailyHeaderStyle, DaySortDirection } from "./settings";
+import type { DailyHeaderStyle, DaySortDirection, OpenNoteAction } from "./settings";
 import { JournalView, VIEW_TYPE_JOURNAL } from "./view";
 
 export default class JournalViewPlugin extends Plugin {
@@ -259,6 +259,7 @@ export default class JournalViewPlugin extends Plugin {
 			filterRules: filterRulesSetting(saved.filterRules),
 			showTags: booleanSetting(saved.showTags, DEFAULT_SETTINGS.showTags),
 			displayProperties: propertyNamesSetting(saved.displayProperties),
+			openNoteAction: openNoteActionSetting(saved.openNoteAction),
 			daySortDirection: daySortDirectionSetting(saved.daySortDirection),
 		};
 	}
@@ -324,4 +325,8 @@ function propertyNamesSetting(value: unknown): string[] {
 
 function daySortDirectionSetting(value: unknown): DaySortDirection {
 	return value === "descending" ? "descending" : DEFAULT_SETTINGS.daySortDirection;
+}
+
+function openNoteActionSetting(value: unknown): OpenNoteAction {
+	return value === "hidden" || value === "heading" ? value : DEFAULT_SETTINGS.openNoteAction;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,7 @@ export const LEGACY_FULL_HEADER_FORMAT = "dddd, D MMMM YYYY";
 
 export type DaySortDirection = "ascending" | "descending";
 export type DailyHeaderStyle = "subtle" | "h1" | "hidden";
+export type OpenNoteAction = "button" | "hidden" | "heading";
 export type JournalFilterMode = "include" | "exclude";
 export type JournalFilterValue = string | number | boolean;
 
@@ -56,6 +57,8 @@ export interface JournalViewSettings {
 	showTags: boolean;
 	/** Frontmatter property names shown above each existing note's body. */
 	displayProperties: string[];
+	/** How readers open a daily note from its journal header. */
+	openNoteAction: OpenNoteAction;
 	/** Chronological direction in which days are laid out. */
 	daySortDirection: DaySortDirection;
 }
@@ -78,6 +81,7 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	filterRules: [],
 	showTags: false,
 	displayProperties: [],
+	openNoteAction: "button",
 	daySortDirection: "ascending",
 };
 
@@ -128,6 +132,11 @@ type JournalDropdownControl =
 			type: "dropdown";
 			key: "headerStyle";
 			options: Record<DailyHeaderStyle, string>;
+	  }
+	| {
+			type: "dropdown";
+			key: "openNoteAction";
+			options: Record<OpenNoteAction, string>;
 	  };
 
 interface JournalDropdownSetting extends JournalSettingBase {
@@ -224,6 +233,19 @@ export class JournalViewSettingTab extends PluginSettingTab {
 							type: "dropdown",
 							key: "headerStyle",
 							options: { subtle: "Subtle", h1: "H1", hidden: "Hidden" },
+						},
+					},
+					{
+						name: "Open note control",
+						desc: "Keep the open-note button, remove it, or open the note by clicking its daily heading.",
+						control: {
+							type: "dropdown",
+							key: "openNoteAction",
+							options: {
+								button: "Show button (default)",
+								hidden: "Hide button",
+								heading: "Use clickable heading",
+							},
 						},
 					},
 					{
@@ -334,6 +356,12 @@ export class JournalViewSettingTab extends PluginSettingTab {
 				break;
 			case "headerStyle":
 				if (value === "subtle" || value === "h1" || value === "hidden") {
+					this.plugin.settings[key] = value;
+					changed = true;
+				}
+				break;
+			case "openNoteAction":
+				if (value === "button" || value === "hidden" || value === "heading") {
 					this.plugin.settings[key] = value;
 					changed = true;
 				}

--- a/src/view.ts
+++ b/src/view.ts
@@ -162,6 +162,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	async onOpen(): Promise<void> {
 		this.containerEl.addClass("journal-view");
+		this.syncOpenNoteSettings();
 		this.contentEl.empty();
 		this.contentEl.addClass("journal-content");
 
@@ -1264,6 +1265,16 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.toolbar?.setFilter(isFilterActive(this.plugin.settings));
 	}
 
+	private syncOpenNoteSettings(): void {
+		const { headerStyle, openNoteAction } = this.plugin.settings;
+		const opensFromHeading = openNoteAction === "heading" && headerStyle !== "hidden";
+		this.containerEl.toggleClass(
+			"journal-open-note-button-hidden",
+			openNoteAction === "hidden" || opensFromHeading,
+		);
+		for (const section of this.sections) section.syncHeaderSettings();
+	}
+
 	/** Settings whose existing day DOM cannot adopt safely in place. */
 	private rebuildSettingsSignature(): string {
 		const settings = this.plugin.settings;
@@ -1286,6 +1297,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.plugin.filteredIndex.ensureCurrent();
 		this.syncWithIndex();
 		this.syncFilterButton();
+		this.syncOpenNoteSettings();
 		if (!this.ready) {
 			// A build is in flight against the old values - dropping the change
 			// here would leave the toolbar and the days disagreeing.

--- a/styles.css
+++ b/styles.css
@@ -305,6 +305,16 @@ button.journal-find-button.is-active {
 	display: none;
 }
 
+.journal-day-title-clickable {
+	border-radius: var(--radius-s);
+	cursor: var(--cursor-link, pointer);
+}
+
+.journal-day-title-clickable:focus-visible {
+	outline: 2px solid var(--background-modifier-border-focus, var(--interactive-accent));
+	outline-offset: var(--size-2-1);
+}
+
 .journal-day-date {
 	min-width: 0;
 	font-size: var(--font-ui-small);
@@ -374,6 +384,10 @@ button.journal-find-button.is-active {
 	opacity: 0;
 	transition: opacity 120ms ease-in-out;
 	flex: 0 0 auto;
+}
+
+.journal-open-note-button-hidden .journal-day-open {
+	display: none;
 }
 
 .journal-day:hover .journal-day-actions,


### PR DESCRIPTION
## Summary

- add Button, Hidden, and Clickable heading choices for opening a daily note
- retain keyboard access, tooltips, and modifier-click new-tab behavior
- keep the button available when the daily header is hidden

## Verification

- npm run typecheck
- npm run build