### PR TITLE
Add an option to hide daily header dividers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Some Customization is only visible in the customization menu accessible from the
 | Day order | Oldest to newest | Reverses the complete timeline when set to newest to oldest |
 | Daily header format | `dddd, D MMMM` | Controls how each daily header displays its date |
 | Daily header style | Subtle | Shows each date subtly, as an H1, or hides the date display |
+| Hide header separator | Off | Removes the line between each daily heading and its note contents |
 | Group days by year | On | Marks year boundaries between consecutive visible daily entries |
 | Group days by month | Off | Groups daily entries beneath compact month and year headings |
 | Focus today on open | On | Opens the journal at today's note and places the cursor there |

--- a/src/main.ts
+++ b/src/main.ts
@@ -256,6 +256,10 @@ export default class JournalViewPlugin extends Plugin {
 			richEditor: booleanSetting(saved.richEditor, DEFAULT_SETTINGS.richEditor),
 			focusTodayOnOpen: booleanSetting(saved.focusTodayOnOpen, DEFAULT_SETTINGS.focusTodayOnOpen),
 			hideEmptyDays: booleanSetting(saved.hideEmptyDays, DEFAULT_SETTINGS.hideEmptyDays),
+			hideHeaderSeparator: booleanSetting(
+				saved.hideHeaderSeparator,
+				DEFAULT_SETTINGS.hideHeaderSeparator,
+			),
 			filterRules: filterRulesSetting(saved.filterRules),
 			showTags: booleanSetting(saved.showTags, DEFAULT_SETTINGS.showTags),
 			displayProperties: propertyNamesSetting(saved.displayProperties),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -50,6 +50,8 @@ export interface JournalViewSettings {
 	focusTodayOnOpen: boolean;
 	/** Show only days that have a note (today always shows). */
 	hideEmptyDays: boolean;
+	/** Hide the rule between a daily header and its note body. */
+	hideHeaderSeparator: boolean;
 	/** Tag and property rules that decide which existing notes are visible. */
 	filterRules: JournalFilterRule[];
 	/** Show frontmatter tags above each existing note's body. */
@@ -75,6 +77,7 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	richEditor: true,
 	focusTodayOnOpen: true,
 	hideEmptyDays: true,
+	hideHeaderSeparator: false,
 	filterRules: [],
 	showTags: false,
 	displayProperties: [],
@@ -87,6 +90,7 @@ type ToggleSettingKey =
 	| "richEditor"
 	| "focusTodayOnOpen"
 	| "hideEmptyDays"
+	| "hideHeaderSeparator"
 	| "showMonthSeparators"
 	| "groupDaysByYear";
 
@@ -227,6 +231,11 @@ export class JournalViewSettingTab extends PluginSettingTab {
 						},
 					},
 					{
+						name: "Hide header separator",
+						desc: "Remove the line between each daily heading and its note contents.",
+						control: { type: "toggle", key: "hideHeaderSeparator" },
+					},
+					{
 						name: "Group days by year",
 						desc: "Show a centered year heading when consecutive visible days cross a year boundary.",
 						control: { type: "toggle", key: "groupDaysByYear" },
@@ -341,6 +350,7 @@ export class JournalViewSettingTab extends PluginSettingTab {
 			case "richEditor":
 			case "focusTodayOnOpen":
 			case "hideEmptyDays":
+			case "hideHeaderSeparator":
 			case "showMonthSeparators":
 			case "groupDaysByYear":
 				if (typeof value === "boolean") {

--- a/src/view.ts
+++ b/src/view.ts
@@ -162,6 +162,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	async onOpen(): Promise<void> {
 		this.containerEl.addClass("journal-view");
+		this.syncDisplaySettings();
 		this.contentEl.empty();
 		this.contentEl.addClass("journal-content");
 
@@ -1264,6 +1265,13 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.toolbar?.setFilter(isFilterActive(this.plugin.settings));
 	}
 
+	private syncDisplaySettings(): void {
+		this.containerEl.toggleClass(
+			"journal-header-separator-hidden",
+			this.plugin.settings.hideHeaderSeparator,
+		);
+	}
+
 	/** Settings whose existing day DOM cannot adopt safely in place. */
 	private rebuildSettingsSignature(): string {
 		const settings = this.plugin.settings;
@@ -1286,6 +1294,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.plugin.filteredIndex.ensureCurrent();
 		this.syncWithIndex();
 		this.syncFilterButton();
+		this.syncDisplaySettings();
 		if (!this.ready) {
 			// A build is in flight against the old values - dropping the change
 			// here would leave the toolbar and the days disagreeing.

--- a/styles.css
+++ b/styles.css
@@ -294,6 +294,10 @@ button.journal-find-button.is-active {
 	transition: opacity 120ms ease-in-out;
 }
 
+.journal-header-separator-hidden .journal-day-header {
+	border-bottom-color: transparent;
+}
+
 .journal-day-title {
 	display: flex;
 	align-items: baseline;


### PR DESCRIPTION
## Summary

- add a setting that removes the divider beneath Subtle daily headers
- leave the existing borderless H1 and Hidden header styles unchanged
- update open Journal View panes when the setting changes

## Verification

- npm run typecheck
- npm run build