### PR TITLE
Add an open-journal-on-startup setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Some Customization is only visible in the customization menu accessible from the
 | Group days by year | On | Marks year boundaries between consecutive visible daily entries |
 | Group days by month | Off | Groups daily entries beneath compact month and year headings |
 | Focus today on open | On | Opens the journal at today's note and places the cursor there |
+| Open journal on startup | Off | Opens or reveals Journal View after Obsidian restores the workspace |
 | Only show days that have a note | On | Skips empty days while always keeping today visible; turn it off to show every day |
 | Rich editor | On | Uses Obsidian's Markdown editor; turn it off to use the plain-text fallback |
 | Autosave delay | 2000 ms | Sets how long Journal View waits after typing before saving |
@@ -61,6 +62,12 @@ Every include filter must match. A note matching any exclude filter is hidden, e
 all includes. The funnel uses the accent color whenever a tag or property filter is active; the
 note-only toggle does not highlight it. Filtered dates are disabled in **Go to date**, and **Find in
 journal** searches only the notes currently included.
+
+## Startup
+
+Journal View is a custom view, so the Homepage plugin cannot select it as a homepage note. Enable
+**Open journal on startup** in Journal View instead. If you also use Homepage, configure only one of
+the two plugins to open content at startup so they do not compete for the active tab.
 
 ## Privacy
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,6 +113,12 @@ export default class JournalViewPlugin extends Plugin {
 		this.register(() => this.clearDailyNoteActions());
 
 		this.registerView(VIEW_TYPE_JOURNAL, (leaf) => new JournalView(leaf, this));
+		this.app.workspace.onLayoutReady(() => {
+			if (!this.settings.openJournalOnStartup) return;
+			void this.activateView(false).catch((error: unknown) => {
+				console.error("Journal View: could not open on startup", error);
+			});
+		});
 
 		this.addRibbonIcon("notebook", "Open journal", () => void this.activateView());
 
@@ -255,6 +261,10 @@ export default class JournalViewPlugin extends Plugin {
 			maxLoadedDays: loadedDaysSetting(saved.maxLoadedDays),
 			richEditor: booleanSetting(saved.richEditor, DEFAULT_SETTINGS.richEditor),
 			focusTodayOnOpen: booleanSetting(saved.focusTodayOnOpen, DEFAULT_SETTINGS.focusTodayOnOpen),
+			openJournalOnStartup: booleanSetting(
+				saved.openJournalOnStartup,
+				DEFAULT_SETTINGS.openJournalOnStartup,
+			),
 			hideEmptyDays: booleanSetting(saved.hideEmptyDays, DEFAULT_SETTINGS.hideEmptyDays),
 			filterRules: filterRulesSetting(saved.filterRules),
 			showTags: booleanSetting(saved.showTags, DEFAULT_SETTINGS.showTags),

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,10 +70,17 @@ export default class JournalViewPlugin extends Plugin {
 		this.daily = new DailyNoteResolver(this.app, () => this.settings);
 		this.index = new DailyNoteIndex(this.app, this.daily);
 		this.filteredIndex = new FilteredDailyNoteIndex(this.app, this.index, () => this.settings.filterRules);
+		// onLayoutReady queues callbacks without returning an EventRef, so they
+		// need an explicit guard when the plugin unloads before layout restoration.
+		let layoutReadyCallbacksEnabled = true;
+		this.register(() => {
+			layoutReadyCallbacksEnabled = false;
+		});
 
 		// The index has to be registered before any view, so it is already up to
 		// date by the time a view reacts to the same vault event.
 		this.app.workspace.onLayoutReady(() => {
+			if (!layoutReadyCallbacksEnabled) return;
 			this.index.rebuild();
 			this.filteredIndex.rebuild();
 			this.syncDailyNoteActions();
@@ -114,7 +121,7 @@ export default class JournalViewPlugin extends Plugin {
 
 		this.registerView(VIEW_TYPE_JOURNAL, (leaf) => new JournalView(leaf, this));
 		this.app.workspace.onLayoutReady(() => {
-			if (!this.settings.openJournalOnStartup) return;
+			if (!layoutReadyCallbacksEnabled || !this.settings.openJournalOnStartup) return;
 			void this.activateView(false).catch((error: unknown) => {
 				console.error("Journal View: could not open on startup", error);
 			});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -48,6 +48,8 @@ export interface JournalViewSettings {
 	richEditor: boolean;
 	/** Put the cursor in today's note when the view opens. */
 	focusTodayOnOpen: boolean;
+	/** Open or reveal the journal after Obsidian restores the workspace. */
+	openJournalOnStartup: boolean;
 	/** Show only days that have a note (today always shows). */
 	hideEmptyDays: boolean;
 	/** Tag and property rules that decide which existing notes are visible. */
@@ -74,6 +76,7 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	maxLoadedDays: 60,
 	richEditor: true,
 	focusTodayOnOpen: true,
+	openJournalOnStartup: false,
 	hideEmptyDays: true,
 	filterRules: [],
 	showTags: false,
@@ -86,6 +89,7 @@ type TextSettingKey = "dateFormat" | "folder" | "templatePath" | "headerFormat";
 type ToggleSettingKey =
 	| "richEditor"
 	| "focusTodayOnOpen"
+	| "openJournalOnStartup"
 	| "hideEmptyDays"
 	| "showMonthSeparators"
 	| "groupDaysByYear";
@@ -252,6 +256,17 @@ export class JournalViewSettingTab extends PluginSettingTab {
 			},
 			{
 				type: "group",
+				heading: "Startup",
+				items: [
+					{
+						name: "Open journal on startup",
+						desc: "Open or reveal Journal View after Obsidian restores the workspace.",
+						control: { type: "toggle", key: "openJournalOnStartup" },
+					},
+				],
+			},
+			{
+				type: "group",
 				heading: "Advanced",
 				items: [
 					{
@@ -340,6 +355,7 @@ export class JournalViewSettingTab extends PluginSettingTab {
 				break;
 			case "richEditor":
 			case "focusTodayOnOpen":
+			case "openJournalOnStartup":
 			case "hideEmptyDays":
 			case "showMonthSeparators":
 			case "groupDaysByYear":


### PR DESCRIPTION
## Summary

- add an optional Open journal on startup setting
- open or reveal Journal View after Obsidian restores the workspace
- document its interaction with homepage-style plugins

## Verification

- npm run typecheck
- npm run build