### PR TITLE
Fix mobile date picker styling and add iOS test deployment

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,11 @@ export default defineConfig(
 			globals: globals.browser,
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: ["eslint.config.mjs", "manifest.json"],
+					allowDefaultProject: [
+						"eslint.config.mjs",
+						"manifest.json",
+						"scripts/deploy-ios-test-vault.mjs",
+					],
 				},
 				tsconfigRootDir: import.meta.dirname,
 				extraFileExtensions: [".json"],
@@ -25,4 +29,15 @@ export default defineConfig(
 		},
 	},
 	...obsidianmd.configs.recommended,
+	{
+		files: ["scripts/deploy-ios-test-vault.mjs"],
+		languageOptions: { globals: globals.node },
+		rules: {
+			// This is a Node-based development script, not code bundled into the
+			// mobile plugin. It deliberately manages a test vault's `.obsidian` files.
+			"obsidianmd/hardcoded-config-path": "off",
+			"obsidianmd/no-nodejs-modules": "off",
+			"obsidianmd/rule-custom-message": "off",
+		},
+	},
 );

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"lint": "eslint .",
 		"typecheck": "tsc -noEmit -skipLibCheck",
 		"test-vault": "bash scripts/setup-test-vault.sh",
+		"deploy:ios": "node scripts/deploy-ios-test-vault.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [

--- a/scripts/deploy-ios-test-vault.mjs
+++ b/scripts/deploy-ios-test-vault.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import {
+	cpSync,
+	copyFileSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PLUGIN_ID = "journal-view";
+const DEFAULT_VAULT_NAME = "Journal View Test";
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const root = realpathSync(join(scriptDir, ".."));
+const sourceVault = join(root, "test-vault");
+const defaultIcloudRoot = join(
+	homedir(),
+	"Library",
+	"Mobile Documents",
+	"iCloud~md~obsidian",
+	"Documents",
+);
+
+function fail(message) {
+	console.error(`\n${message}`);
+	process.exit(1);
+}
+
+function runNpm(script) {
+	try {
+		execFileSync("npm", ["run", script], { cwd: root, stdio: "inherit" });
+	} catch {
+		fail(`npm run ${script} failed.`);
+	}
+}
+
+function destinationFromArgs() {
+	if (process.argv.length > 3) {
+		fail("Usage: npm run deploy:ios -- [absolute-vault-path]");
+	}
+
+	const configured = process.argv[2] ?? process.env.JOURNAL_VIEW_IOS_VAULT;
+	if (configured && !isAbsolute(configured)) {
+		fail("The iOS test-vault path must be absolute.");
+	}
+	if (!configured && !existsSync(defaultIcloudRoot)) {
+		fail(
+			`Obsidian's iCloud folder was not found at:\n${defaultIcloudRoot}\n\n` +
+				"Create or open an iCloud-based vault in Obsidian first, or pass a destination:\n" +
+				"npm run deploy:ios -- /absolute/path/to/vault",
+		);
+	}
+
+	return resolve(configured ?? join(defaultIcloudRoot, DEFAULT_VAULT_NAME));
+}
+
+function assertSafeDestination(destination) {
+	const filesystemRoot = parse(destination).root;
+	if (destination === filesystemRoot || destination === root || destination === sourceVault) {
+		fail(`Refusing to deploy over unsafe destination: ${destination}`);
+	}
+
+	const fromRoot = relative(root, destination);
+	if (fromRoot === ".." || (fromRoot && !fromRoot.startsWith(`..${sep}`))) {
+		fail("The iOS test vault must not be the repository's parent or a path inside the repository.");
+	}
+
+	const existing = lstatSync(destination, { throwIfNoEntry: false });
+	if (!existing) return;
+	if (!existing.isDirectory()) fail(`The destination is not a directory: ${destination}`);
+	if (readdirSync(destination).length === 0) return;
+
+	const configDirectory = lstatSync(join(destination, ".obsidian"), { throwIfNoEntry: false });
+	if (!configDirectory?.isDirectory()) {
+		fail(`${destination} is not empty and is not an Obsidian vault.`);
+	}
+}
+
+function copyTestVault(destination) {
+	const pluginSource = join(sourceVault, ".obsidian", "plugins", PLUGIN_ID);
+	const filesOwnedByIos = new Set([
+		join(sourceVault, ".obsidian", "community-plugins.json"),
+		join(sourceVault, ".obsidian", "workspace.json"),
+		join(sourceVault, ".obsidian", "workspace-mobile.json"),
+	]);
+	const ignoredVaultDirectories = [join(sourceVault, ".trash"), join(sourceVault, "Untitled")];
+
+	cpSync(sourceVault, destination, {
+		force: true,
+		preserveTimestamps: true,
+		recursive: true,
+		filter(source) {
+			if (basename(source) === ".DS_Store") return false;
+			if (
+				ignoredVaultDirectories.some(
+					(directory) => source === directory || source.startsWith(`${directory}${sep}`),
+				)
+			) {
+				return false;
+			}
+			if (source === pluginSource || source.startsWith(`${pluginSource}${sep}`)) return false;
+			if (filesOwnedByIos.has(source)) return false;
+			// iCloud does not provide a useful deployment path for repository
+			// symlinks. The plugin itself is installed as real files below.
+			return !lstatSync(source).isSymbolicLink();
+		},
+	});
+}
+
+function installPlugin(destination) {
+	const pluginDestination = join(destination, ".obsidian", "plugins", PLUGIN_ID);
+	const existing = lstatSync(pluginDestination, { throwIfNoEntry: false });
+	if (existing && !existing.isDirectory()) {
+		rmSync(pluginDestination, { force: true, recursive: true });
+	}
+	mkdirSync(pluginDestination, { recursive: true });
+
+	for (const artifact of ["main.js", "manifest.json", "styles.css"]) {
+		const source = join(root, artifact);
+		if (!existsSync(source)) fail(`Build artifact is missing: ${source}`);
+		copyFileSync(source, join(pluginDestination, artifact));
+	}
+}
+
+function enablePlugin(destination) {
+	const config = join(destination, ".obsidian", "community-plugins.json");
+	let enabled = [];
+	if (existsSync(config)) {
+		try {
+			enabled = JSON.parse(readFileSync(config, "utf8"));
+		} catch (error) {
+			fail(`Could not read ${config}: ${error.message}`);
+		}
+		if (!Array.isArray(enabled) || !enabled.every((entry) => typeof entry === "string")) {
+			fail(`Expected ${config} to contain a JSON array of plugin IDs.`);
+		}
+	}
+
+	if (!enabled.includes(PLUGIN_ID)) enabled.push(PLUGIN_ID);
+	mkdirSync(dirname(config), { recursive: true });
+	writeFileSync(config, `${JSON.stringify(enabled, null, "\t")}\n`);
+}
+
+const destination = destinationFromArgs();
+assertSafeDestination(destination);
+
+console.log(`Deploying Journal View to ${destination}\n`);
+runNpm("test-vault");
+runNpm("build");
+mkdirSync(destination, { recursive: true });
+copyTestVault(destination);
+installPlugin(destination);
+enablePlugin(destination);
+
+console.log(`\niOS test vault deployed to:\n${destination}`);
+console.log(
+	`\nWait for iCloud to finish syncing, open "${basename(destination)}" on iOS, ` +
+		"then restart Obsidian or toggle Journal View off and on after later deployments.",
+);

--- a/scripts/setup-test-vault.sh
+++ b/scripts/setup-test-vault.sh
@@ -4,8 +4,8 @@
 # hand. The vault itself is gitignored; this script is what makes it
 # reproducible, so run it instead of hand-rolling a vault.
 #
-# Existing files are left alone, so it is safe to re-run over a vault you have
-# already been typing in.
+# Existing vault content is left alone, so it is safe to re-run over a vault you
+# have already been typing in. The generated testing guide is refreshed.
 #
 # Usage: npm run test-vault
 set -euo pipefail
@@ -29,6 +29,16 @@ write() { # write <relative path> - from stdin, only when the file is missing
 		cat >"$path"
 		echo "  created $1"
 	fi
+}
+
+write_managed() { # write_managed <relative path> - from stdin, replacing generated documentation
+	local path="$vault/$1"
+	local action="created"
+	if [ -e "$path" ]; then
+		action="updated"
+	fi
+	cat >"$path"
+	echo "  $action $1"
 }
 
 write .obsidian/core-plugins.json <<'JSON'
@@ -120,7 +130,7 @@ tags:
 ## Notes
 MARKDOWN
 
-write README-TESTING.md <<'MARKDOWN'
+write_managed README-TESTING.md <<'MARKDOWN'
 # Journal View test vault
 
 Throwaway vault for exercising the plugin by hand. Gitignored, so anything written
@@ -182,6 +192,41 @@ Two things will waste your afternoon if you do not know them:
 Useful while debugging: `dev:errors` (unhandled rejections land here), `dev:console`,
 `dev:dom selector=...`, and `dev:cdp method=Input.insertText params='{"text":"..."}'`
 to type into whatever holds focus.
+
+## Testing on iOS
+
+Desktop mobile emulation still runs Chromium, so use a physical iPhone or iPad
+for WebKit, touch and momentum-scrolling issues. This command builds the plugin,
+copies this test vault into Obsidian's iCloud container as `Journal View Test`,
+installs real plugin files instead of the repository symlink, and adds Journal
+View to the vault's enabled community plugins:
+
+```bash
+npm run deploy:ios
+```
+
+The default destination is:
+
+```text
+~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Journal View Test
+```
+
+If the iCloud container is elsewhere, pass the absolute vault path directly or
+set `JOURNAL_VIEW_IOS_VAULT`:
+
+```bash
+npm run deploy:ios -- "/absolute/path/to/Journal View Test"
+JOURNAL_VIEW_IOS_VAULT="/absolute/path/to/Journal View Test" npm run deploy:ios
+```
+
+Deploying again updates the build and matching test-vault files without deleting
+files created only on iOS. It also preserves the iOS workspace and any other
+enabled community plugins. Wait for iCloud to finish syncing, then restart
+Obsidian or toggle Journal View off and on to load the new build.
+
+For Safari Web Inspector, enable **Settings -> Apps -> Safari -> Advanced -> Web
+Inspector** on iOS. Enable developer features in Safari on the Mac, connect the
+device, open this vault, and select Obsidian under **Develop -> [device]**.
 
 ## Checks worth running
 

--- a/styles.css
+++ b/styles.css
@@ -929,7 +929,7 @@ body.is-phone .journal-view .view-content .journal-day-editing .journal-day-body
 	align-items: baseline;
 	gap: var(--size-2-2);
 	padding: var(--size-4-2) 0 var(--size-2-2);
-	background-color: var(--background-primary);
+	background-color: var(--modal-background);
 	font-size: var(--font-ui-small);
 	font-weight: var(--font-semibold);
 	color: var(--text-normal);


### PR DESCRIPTION
## Summary

- match the mobile date picker month background to the surrounding modal
- add a safe npm run deploy:ios workflow for building and copying the disposable test vault to Obsidian on iCloud
- preserve iOS workspace state and enable Journal View without copying repository symlinks

## Verification

- npm run typecheck
- npm run build
- npm run lint
- deployed and redeployed a temporary vault, including preservation and safety checks
- deployed and verified the Journal View Test vault in the Obsidian iCloud container