### PR TITLE
Support Completed Tasks in journal entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Yesterday and tomorrow are shown while focused even when the note-only toggle or
 would normally hide them. All three commands scroll when the target is nearby and snap when it is
 more than two view heights away.
 
+## Completed Tasks
+
+When Completed Tasks is enabled, its sorting rules also apply inside the active journal entry.
+Its interval, task statuses, priorities, ignored words, and `completedTasks: false` setting are
+respected. An interval of zero disables automatic sorting. Reorder on tab change also sorts an
+edited entry when you leave it. Neither plugin modifies the other plugin's files or settings.
+
 ## Privacy
 
 Journal View works locally with files in your Obsidian vault. It does not make network requests,

--- a/src/completedTasks.ts
+++ b/src/completedTasks.ts
@@ -1,0 +1,57 @@
+import type { App, Editor, EditorPosition, TFile } from "obsidian";
+import type { JournalEditor } from "./editor";
+
+type SortingEditor = Pick<Editor, "getCursor" | "getValue" | "setValue" | "setSelection">;
+
+interface CompletedTasksPlugin {
+	settings: { intervalSeconds: number; reorderOnTabChange: boolean };
+	reorderView(view: { file: TFile; editor: SortingEditor }): void;
+}
+
+/** Read the enabled plugin each time so disabling it or changing settings takes effect. */
+export function completedTasksPlugin(app: App): CompletedTasksPlugin | null {
+	const plugin = app.plugins?.getPlugin("completed-tasks") as Partial<CompletedTasksPlugin> | null | undefined;
+	return plugin?.settings && typeof plugin.reorderView === "function" ? plugin as CompletedTasksPlugin : null;
+}
+
+/** Give the existing sorter this day's editor without changing the other plugin. */
+export function reorderCompletedTasks(app: App, file: TFile, editor: JournalEditor): boolean {
+	const plugin = completedTasksPlugin(app);
+	if (!plugin) return false;
+	const before = editor.getValue();
+	let value = before;
+	const initialCursor = editor.getSelectionRange();
+	if (!initialCursor) return false;
+	let cursor = initialCursor;
+	const position = (offset: number): EditorPosition => {
+		const lines = value.slice(0, offset).split("\n");
+		return { line: lines.length - 1, ch: lines[lines.length - 1].length };
+	};
+	const offset = (pos: EditorPosition): number => {
+		const lines = value.split("\n");
+		const line = Math.max(0, Math.min(pos.line, lines.length - 1));
+		return lines.slice(0, line).reduce((sum, text) => sum + text.length + 1, 0) + Math.min(pos.ch, lines[line].length);
+	};
+	const adapter: SortingEditor = {
+		getValue: () => value,
+		getCursor: (which = "head") => position(
+			which === "anchor" ? cursor.anchor : which === "from" ? Math.min(cursor.anchor, cursor.head)
+				: which === "to" ? Math.max(cursor.anchor, cursor.head) : cursor.head,
+		),
+		setValue: (next) => { value = next; },
+		setSelection: (anchor, head = anchor) => { cursor = { anchor: offset(anchor), head: offset(head) }; },
+	};
+	try {
+		// The plugin checks the file's frontmatter itself, including completedTasks: false.
+		// Work on a snapshot first so a failing integration cannot leave a partial edit.
+		plugin.reorderView({ file, editor: adapter });
+		if (value !== before) {
+			editor.setValue(value, true);
+			editor.setSelectionRange(cursor);
+		}
+		return true;
+	} catch (error) {
+		console.warn("Journal View: could not reorder completed tasks", error);
+		return false;
+	}
+}

--- a/src/day.ts
+++ b/src/day.ts
@@ -20,6 +20,7 @@ import { SaveQueue } from "./saveQueue";
 import { findLiteralRanges } from "./findText";
 import type { FindRange } from "./findText";
 import { listenForReaderScrollIntent } from "./readerInput";
+import { completedTasksPlugin, reorderCompletedTasks } from "./completedTasks";
 
 /**
  * Frames a cursor placed at the end of a day is kept on screen for, long
@@ -301,6 +302,7 @@ export class DaySection {
 	private bodyEl: HTMLElement;
 
 	private editor: JournalEditor | null = null;
+	private completedTasksPending = false;
 	private previewComponent: Component | null = null;
 	private destroyed = false;
 	/**
@@ -1641,6 +1643,7 @@ export class DaySection {
 						this.releaseHeight();
 					},
 					onChange: () => {
+						if (this.editor && this.isDirty) this.completedTasksPending = true;
 						this.releaseHeight();
 						this.updateBlankState();
 						this.scheduleSave();
@@ -1740,6 +1743,7 @@ export class DaySection {
 		this.el.removeClass("journal-day-focused");
 		// Leaving a day the reader only looked at costs them nothing.
 		if (this.withdrawTemplate()) return;
+		if (completedTasksPlugin(this.host.app)?.settings.reorderOnTabChange) this.sortCompletedTasks();
 		void this.flush().finally(() => {
 			if (!this.destroyed) this.host.onDayFocusChanged(this);
 		});
@@ -1876,6 +1880,20 @@ export class DaySection {
 	}
 
 	/* ---------------------------------------------------------------- saving */
+
+	sortCompletedTasks(force = false): boolean {
+		if (this.destroyed || !this.editor || !this.file || ("saveConflict" in this && this.saveConflict === true) || this.externalReloadPending) return false;
+		if (!force && !this.completedTasksPending) return false;
+		const before = this.editor.getValue();
+		if (!reorderCompletedTasks(this.host.app, this.file, this.editor)) return false;
+		this.completedTasksPending = false;
+		if (this.editor.getValue() !== before) {
+			this.updateBlankState();
+			this.host.onDayContentChanged(this);
+			void this.flush();
+		}
+		return true;
+	}
 
 	private scheduleSave(): void {
 		window.clearTimeout(this.saveTimer);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4,6 +4,10 @@ import type { EditorState, TransactionSpec } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import type { DecorationSet } from "@codemirror/view";
 import type { FindRange } from "./findText";
+export interface TextSelection {
+	anchor: number;
+	head: number;
+}
 
 export interface JournalEditorOptions {
 	app: App;
@@ -24,6 +28,8 @@ export interface JournalEditorOptions {
 
 export interface JournalEditor {
 	getValue(): string;
+	getSelectionRange(): TextSelection | null;
+	setSelectionRange(selection: TextSelection): void;
 	/** Replaces the contents; `preserveSelection` is for a clean external update. */
 	setValue(value: string, preserveSelection?: boolean): void;
 	setFile(file: TFile | null): void;
@@ -472,6 +478,16 @@ class RichEditor implements JournalEditor {
 		return this.readValue() ?? "";
 	}
 
+	getSelectionRange(): TextSelection | null {
+		const range = this.instance?.editor?.cm?.state?.selection.main;
+		return range ? { anchor: range.anchor, head: range.head } : null;
+	}
+
+	setSelectionRange(selection: TextSelection): void {
+		this.instance?.editor?.cm?.dispatch?.({ selection });
+		this.dropScrollRequest();
+	}
+
 	setValue(value: string, preserveSelection = false): void {
 		try {
 			// Obsidian's non-clearing path applies the smallest document change,
@@ -681,6 +697,15 @@ class PlainEditor implements JournalEditor {
 
 	getValue(): string {
 		return this.textarea.value;
+	}
+
+	getSelectionRange(): TextSelection {
+		const { selectionStart: start, selectionEnd: end, selectionDirection } = this.textarea;
+		return selectionDirection === "backward" ? { anchor: end, head: start } : { anchor: start, head: end };
+	}
+
+	setSelectionRange({ anchor, head }: TextSelection): void {
+		this.textarea.setSelectionRange(Math.min(anchor, head), Math.max(anchor, head), head < anchor ? "backward" : "forward");
 	}
 
 	setValue(value: string, preserveSelection = false): void {

--- a/src/view.ts
+++ b/src/view.ts
@@ -15,6 +15,7 @@ import type { FindRange } from "./findText";
 import { createMoment } from "./moment";
 import type { Moment } from "./moment";
 import { listenForReaderScrollIntent } from "./readerInput";
+import { completedTasksPlugin } from "./completedTasks";
 
 export const VIEW_TYPE_JOURNAL = "journal-view";
 
@@ -90,6 +91,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	private endPendingFocusCenter: (() => void) | null = null;
 	/** Delayed editor focus used only by the initial open on today. */
 	private initialFocusTimer = 0;
+	private lastTaskSort = Date.now();
+	private lastEditedDay: DaySection | null = null;
 	/** Cursor placement requested while the pane still had no measurable height. */
 	private focusOnFirstResizeAtEnd: boolean | null = null;
 	/** Command target kept visible only until its editor receives focus. */
@@ -189,6 +192,14 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.registerDomEvent(window, "pointerup", () => (this.pointerHeld = false), { passive: true });
 		this.registerDomEvent(this.containerEl, "keydown", (event) => this.onKeydown(event), { capture: true });
 		this.registerVaultEvents();
+		this.registerInterval(window.setInterval(() => {
+			if (this.app.workspace.getActiveViewOfType(JournalView) !== this) return;
+			const interval = completedTasksPlugin(this.app)?.settings.intervalSeconds ?? 0;
+			if (!Number.isFinite(interval) || interval <= 0 || Date.now() - this.lastTaskSort < interval * 1000) return;
+			this.lastTaskSort = Date.now();
+			const day = this.sections.find((section) => section.hasFocus) ?? this.lastEditedDay;
+			day?.sortCompletedTasks();
+		}, 500));
 
 		const initialTarget = this.initialTarget;
 		this.initialTarget = undefined;
@@ -1293,7 +1304,8 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		this.syncDateSeparators();
 	}
 
-	onDayContentChanged(_day: DaySection): void {
+	onDayContentChanged(day: DaySection): void {
+		if (day.hasFocus) this.lastEditedDay = day;
 		this.find?.sectionsChanged();
 	}
 


### PR DESCRIPTION
Completed Tasks currently skips Journal View's embedded editors. This lets edited journal entries use the enabled plugin's own sorter, including its interval, reorder-on-tab-change preference, task statuses, priorities, exclusions and `completedTasks: false` frontmatter.

Sorting runs for the active journal entry at the configured interval, or when leaving an edited entry if that preference is enabled. The adapter sorts a snapshot before applying the result, so a sorter error cannot apply a partial change. Completed Tasks remains optional; its files and settings are untouched.

Validation: typecheck, production build and lint passed. Six focused checks against the installed Completed Tasks sorter covered ordering, nested tasks, exclusions, disabled integration and failure handling. These used a mock editor; live Obsidian interaction testing is still needed.

This draft is based on upstream `dev` and contains only the Completed Tasks integration. It shares the small editor-selection API with the separate expanding-selection change.
