### PR TITLE
Add expanding line, section and note selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Yesterday and tomorrow are shown while focused even when the note-only toggle or
 would normally hide them. All three commands scroll when the target is nearby and snap when it is
 more than two view heights away.
 
+## Expanding selection
+
+Inside a journal entry, Cmd+A on Mac or Ctrl+A on Windows/Linux selects the current line without
+its list or task marker. Press again to select the current heading's contents, then once more
+for the note body without its leading H1. Moving the cursor or editing starts over. This works
+in both the rich editor and the plain-text fallback.
+
 ## Privacy
 
 Journal View works locally with files in your Obsidian vault. It does not make network requests,

--- a/src/day.ts
+++ b/src/day.ts
@@ -20,6 +20,7 @@ import { SaveQueue } from "./saveQueue";
 import { findLiteralRanges } from "./findText";
 import type { FindRange } from "./findText";
 import { listenForReaderScrollIntent } from "./readerInput";
+import { SmartSelection } from "./smartSelection";
 
 /**
  * Frames a cursor placed at the end of a day is kept on screen for, long
@@ -301,6 +302,7 @@ export class DaySection {
 	private bodyEl: HTMLElement;
 
 	private editor: JournalEditor | null = null;
+	private smartSelection = new SmartSelection();
 	private previewComponent: Component | null = null;
 	private destroyed = false;
 	/**
@@ -1743,6 +1745,16 @@ export class DaySection {
 		void this.flush().finally(() => {
 			if (!this.destroyed) this.host.onDayFocusChanged(this);
 		});
+	}
+
+	expandSelection(): boolean {
+		if (!this.editor?.hasFocus()) return false;
+		const selection = this.editor.getSelectionRange();
+		if (!selection) return false;
+		const titleHidden = ("hiddenNotePrefix" in this && typeof this.hiddenNotePrefix === "string") ||
+			("pendingTemplatePrefix" in this && typeof this.pendingTemplatePrefix === "string");
+		this.editor.setSelectionRange(this.smartSelection.expand(this.editor.getValue(), selection, titleHidden));
+		return true;
 	}
 
 	/**

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4,6 +4,10 @@ import type { EditorState, TransactionSpec } from "@codemirror/state";
 import { Decoration, EditorView } from "@codemirror/view";
 import type { DecorationSet } from "@codemirror/view";
 import type { FindRange } from "./findText";
+export interface TextSelection {
+	anchor: number;
+	head: number;
+}
 
 export interface JournalEditorOptions {
 	app: App;
@@ -24,6 +28,8 @@ export interface JournalEditorOptions {
 
 export interface JournalEditor {
 	getValue(): string;
+	getSelectionRange(): TextSelection | null;
+	setSelectionRange(selection: TextSelection): void;
 	/** Replaces the contents; `preserveSelection` is for a clean external update. */
 	setValue(value: string, preserveSelection?: boolean): void;
 	setFile(file: TFile | null): void;
@@ -472,6 +478,16 @@ class RichEditor implements JournalEditor {
 		return this.readValue() ?? "";
 	}
 
+	getSelectionRange(): TextSelection | null {
+		const range = this.instance?.editor?.cm?.state?.selection.main;
+		return range ? { anchor: range.anchor, head: range.head } : null;
+	}
+
+	setSelectionRange(selection: TextSelection): void {
+		this.instance?.editor?.cm?.dispatch?.({ selection });
+		this.dropScrollRequest();
+	}
+
 	setValue(value: string, preserveSelection = false): void {
 		try {
 			// Obsidian's non-clearing path applies the smallest document change,
@@ -681,6 +697,15 @@ class PlainEditor implements JournalEditor {
 
 	getValue(): string {
 		return this.textarea.value;
+	}
+
+	getSelectionRange(): TextSelection {
+		const { selectionStart: start, selectionEnd: end, selectionDirection } = this.textarea;
+		return selectionDirection === "backward" ? { anchor: end, head: start } : { anchor: start, head: end };
+	}
+
+	setSelectionRange({ anchor, head }: TextSelection): void {
+		this.textarea.setSelectionRange(Math.min(anchor, head), Math.max(anchor, head), head < anchor ? "backward" : "forward");
 	}
 
 	setValue(value: string, preserveSelection = false): void {

--- a/src/noteProjection.ts
+++ b/src/noteProjection.ts
@@ -1,0 +1,117 @@
+interface MarkdownLine {
+	text: string;
+	next: number;
+}
+
+export interface ProjectedNoteBody {
+	hiddenPrefix: string | null;
+	editorBody: string;
+}
+
+export interface MergedNoteBody {
+	hiddenPrefix: string | null;
+	body: string;
+}
+
+function markdownLineAt(value: string, start: number): MarkdownLine {
+	let end = start;
+	while (end < value.length && value.charCodeAt(end) !== 10 && value.charCodeAt(end) !== 13) end++;
+	let next = end;
+	if (next < value.length) {
+		if (value.charCodeAt(next) === 13 && value.charCodeAt(next + 1) === 10) next++;
+		next++;
+	}
+	return { text: value.slice(start, end), next };
+}
+
+function isMarkdownBlank(line: string): boolean {
+	return /^[ \t]*$/.test(line);
+}
+
+/**
+ * A deliberately conservative check for a one-line Setext title. Markdown
+ * block constructs take priority over Setext headings, so ambiguous lines are
+ * left visible instead of risking hiding content that is not a title.
+ */
+function isSetextTitle(line: string): boolean {
+	if (isMarkdownBlank(line) || /^(?: {0,3}\t| {4})/.test(line)) return false;
+	const text = line.replace(/^ {0,3}/, "");
+	if (
+		/^(?:#{1,6}(?:[ \t]|$)|>|`{3,}|~{3,}|<|\$\$|%%|[-+*](?:[ \t]+|$)|\d{1,9}[.)](?:[ \t]+|$)|\[[^\]]+\]:)/.test(
+			text,
+		)
+	) {
+		return false;
+	}
+	if (/^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,}|=+[ \t]*)$/.test(text)) return false;
+	return true;
+}
+
+/** Splits a leading ATX or conservative Setext H1, with adjacent blank lines. */
+export function splitLeadingH1(body: string): { hiddenPrefix: string; visibleBody: string } | null {
+	let titleStart = 0;
+	while (titleStart < body.length) {
+		const line = markdownLineAt(body, titleStart);
+		if (!isMarkdownBlank(line.text)) break;
+		titleStart = line.next;
+	}
+	if (titleStart >= body.length) return null;
+
+	const title = markdownLineAt(body, titleStart);
+	let headingEnd = 0;
+	if (/^ {0,3}#(?:[ \t]+.*)?[ \t]*$/.test(title.text)) {
+		headingEnd = title.next;
+	} else {
+		const underline = markdownLineAt(body, title.next);
+		if (
+			title.next >= body.length ||
+			!isSetextTitle(title.text) ||
+			!/^ {0,3}=+[ \t]*$/.test(underline.text)
+		) {
+			return null;
+		}
+		headingEnd = underline.next;
+	}
+
+	while (headingEnd < body.length) {
+		const line = markdownLineAt(body, headingEnd);
+		if (!isMarkdownBlank(line.text)) break;
+		headingEnd = line.next;
+	}
+	return { hiddenPrefix: body.slice(0, headingEnd), visibleBody: body.slice(headingEnd) };
+}
+
+/** CodeMirror stores every line break as `\n`, regardless of the file's EOL. */
+export function normalizeEditorBody(body: string): string {
+	return body.replace(/\r\n?/g, "\n");
+}
+
+export function projectNoteBody(body: string, hideDailyNoteH1: boolean): ProjectedNoteBody {
+	const split = hideDailyNoteH1 ? splitLeadingH1(body) : null;
+	return {
+		hiddenPrefix: split?.hiddenPrefix ?? null,
+		editorBody: normalizeEditorBody(split?.visibleBody ?? body),
+	};
+}
+
+/**
+ * Recombines an editor body only when the visible part of the latest vault
+ * copy still matches the editor's base. The omission decision stays fixed for
+ * editors that did not start with an H1. An editor that did omit one can safely
+ * accept a title-only rename or removal while keeping visible-body conflicts.
+ */
+export function mergeProjectedNoteBody(
+	latestBody: string,
+	baseEditorBody: string,
+	editorBody: string,
+	hiddenPrefix: string | null,
+): MergedNoteBody | null {
+	const latest = hiddenPrefix === null ? null : splitLeadingH1(latestBody);
+	const latestEditorBody = normalizeEditorBody(latest?.visibleBody ?? latestBody);
+	if (latestEditorBody !== baseEditorBody) return null;
+
+	const prefix = latest?.hiddenPrefix ?? null;
+	const serializedPrefix = prefix ?? "";
+	const separator = serializedPrefix && editorBody && !/[\r\n]$/.test(serializedPrefix) ? "\n" : "";
+	return { hiddenPrefix: prefix, body: serializedPrefix + separator + editorBody };
+}

--- a/src/smartSelection.ts
+++ b/src/smartSelection.ts
@@ -1,0 +1,67 @@
+import { splitLeadingH1 } from "./noteProjection";
+import type { TextSelection } from "./editor";
+
+interface Range {
+	from: number;
+	to: number;
+}
+
+const LIST_MARKER = /^[ \t]*(?:[-*+]|\d+[.)])[ \t]+(?:\[[^\]\r\n]\](?:[ \t]+|$))?/;
+
+/** Selection state belongs to one editor, and resets after a cursor move or edit. */
+export class SmartSelection {
+	private previous: { value: string; range: Range; ranges: Range[]; stage: number } | null = null;
+
+	expand(value: string, selection: TextSelection, titleAlreadyHidden: boolean): TextSelection {
+		const from = Math.min(selection.anchor, selection.head);
+		const to = Math.max(selection.anchor, selection.head);
+		const previous = this.previous;
+		if (previous && previous.value === value && previous.range.from === from && previous.range.to === to) {
+			previous.stage = Math.min(previous.stage + 1, previous.ranges.length - 1);
+			previous.range = previous.ranges[previous.stage];
+			return { anchor: previous.range.from, head: previous.range.to };
+		}
+
+		const start = titleAlreadyHidden ? 0 : (splitLeadingH1(value)?.hiddenPrefix.length ?? 0);
+		const whole = { from: start, to: value.length };
+		const cursor = Math.max(start, Math.min(selection.head, value.length));
+		const lineStart = Math.max(start, cursor === 0 ? 0 : value.lastIndexOf("\n", cursor - 1) + 1);
+		const newline = value.indexOf("\n", cursor);
+		const lineEnd = newline < 0 ? value.length : newline;
+		const marker = value.slice(lineStart, lineEnd).match(LIST_MARKER)?.[0].length ?? 0;
+		const line = { from: lineStart + marker, to: lineEnd };
+
+		// Fenced code can contain # characters that are not section boundaries.
+		const headings: { from: number; end: number }[] = [];
+		let offset = start;
+		let fence: { char: string; length: number } | null = null;
+		for (const text of value.slice(start).split("\n")) {
+			const match = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(text);
+			if (fence) {
+				if (match && match[1][0] === fence.char && match[1].length >= fence.length && !match[2].trim()) {
+					fence = null;
+				}
+			} else if (match) {
+				fence = { char: match[1][0], length: match[1].length };
+			} else if (/^ {0,3}#{1,6}(?:[ \t]+|$)/.test(text)) {
+				headings.push({ from: offset, end: Math.min(value.length, offset + text.length + 1) });
+			}
+			offset += text.length + 1;
+		}
+		let section = whole;
+		for (let index = 0; index < headings.length; index++) {
+			const heading = headings[index];
+			const next = headings[index + 1]?.from ?? value.length;
+			if (heading.from <= cursor && (cursor < next || index === headings.length - 1)) {
+				const body = value.slice(heading.end, next);
+				const leading = body.match(/^(?:[ \t]*\n)*/)?.[0].length ?? 0;
+				const trailing = body.match(/\s*$/)?.[0].length ?? 0;
+				section = { from: heading.end + leading, to: Math.max(heading.end + leading, next - trailing) };
+				break;
+			}
+		}
+		const ranges = [line, section, whole];
+		this.previous = { value, range: line, ranges, stage: 0 };
+		return { anchor: line.from, head: line.to };
+	}
+}

--- a/src/view.ts
+++ b/src/view.ts
@@ -144,6 +144,9 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 			this.showFind();
 			return false;
 		});
+		this.scope.register(["Mod"], "a", () => {
+			if (this.sections.some((section) => section.expandSelection())) return false;
+		});
 		this.initialTarget = plugin.consumeInitialTarget(leaf);
 		// Opening a note (from a day header, or a link inside a day) must not
 		// replace the journal itself.
@@ -738,6 +741,14 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 	}
 
 	private onKeydown(event: KeyboardEvent): void {
+		if (event.defaultPrevented) return;
+		if (event.key.toLowerCase() === "a" && (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey) {
+			if (this.sections.some((section) => section.expandSelection())) {
+				event.preventDefault();
+				event.stopPropagation();
+			}
+			return;
+		}
 		if (
 			event.key.toLowerCase() !== "f" ||
 			(!event.metaKey && !event.ctrlKey) ||


### PR DESCRIPTION
Pressing Cmd+A or Ctrl+A inside a journal entry now selects the current line without its list or task marker. Pressing it again selects the current heading's contents; the third press selects the note body without its leading H1. Moving the cursor or editing resets the sequence.

The selection helper handles task states, numbered lists, ATX and Setext note titles, and heading-like text inside fenced code. Selection access stays in the existing editor adapter, with support for both the rich editor and plain-text fallback.

This is independent of #38. It includes the same leading-title helper and recognises that PR's hidden-title state, so an H1 at the start of the remaining body is still included when the note title is already hidden. It does not add the hide-H1 setting.

Validation: typecheck, production build and lint passed. Nine focused checks covered the three selection stages, title exclusion, markers, fenced code, resets and text bounds. Combined behavior with hidden note titles was also checked in the fork. Live keyboard testing in Obsidian is still needed.
