### PR TITLE
Improve spacing in today's journal entry

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,8 @@
 }
 
 .journal-content {
+	container-type: inline-size;
+	container-name: journal-pane;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
@@ -214,7 +216,7 @@ button.journal-find-button.is-active {
 .journal-day-card {
 	position: relative;
 	border-radius: var(--radius-m);
-	padding: var(--size-4-2) var(--size-4-3) var(--size-4-3);
+	padding: var(--size-4-3) var(--size-4-5) var(--size-4-3);
 	transition: background-color 120ms ease-in-out;
 }
 
@@ -288,8 +290,8 @@ button.journal-find-button.is-active {
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--size-4-2);
-	padding-bottom: var(--size-2-2);
-	margin-bottom: var(--size-2-3);
+	padding-bottom: var(--size-4-2);
+	margin-bottom: var(--size-4-3);
 	border-bottom: 1px solid var(--background-modifier-border);
 	transition: opacity 120ms ease-in-out;
 }
@@ -297,7 +299,7 @@ button.journal-find-button.is-active {
 .journal-day-title {
 	display: flex;
 	align-items: baseline;
-	gap: var(--size-4-2);
+	gap: var(--size-4-3);
 	min-width: 0;
 }
 
@@ -357,6 +359,22 @@ button.journal-find-button.is-active {
 
 /* A quiet marker, not a call to action: today is already highlighted by its
    background, so the badge only has to name it. */
+.journal-day-header-h1 .journal-day-title {
+	flex-wrap: wrap;
+	row-gap: var(--size-2-1);
+	font-family: var(--font-text);
+	font-size: var(--font-text-size);
+}
+
+.journal-day-header-h1 .journal-day-date {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+.journal-day-header-h1 .journal-day-badge {
+	font-family: var(--font-interface);
+}
+
 .journal-day-badge {
 	font-size: var(--font-ui-smaller);
 	font-weight: var(--font-normal);
@@ -721,14 +739,20 @@ button.journal-day-metadata-value-button:focus-visible,
 /* Today gets a quiet highlight so the centre of the journal is obvious. */
 .journal-day-today .journal-day-card {
 	background-color: var(--background-primary-alt);
+	padding-block: var(--size-4-5) var(--size-4-4);
+	border-radius: var(--radius-l, var(--radius-m));
 }
 
-/* ...and more room around its text than the days around it. The bottom stands
-   in for the header stacked above the text, so the two gaps read as even; it
-   is short of that sum because the card's own padding sits under the body. */
+/* The card and header supply the spacing around the embedded note. */
 .journal-day-today .journal-day-body {
-	--journal-body-pad-top: var(--size-4-8);
-	--journal-body-pad-bottom: var(--size-4-12);
+	--journal-body-pad-top: var(--size-2-2);
+	--journal-body-pad-bottom: 0px;
+}
+
+@container journal-pane (max-width: 32rem) {
+	.journal-day-card {
+		padding-inline: var(--size-4-3);
+	}
 }
 
 /* Days without a note yet: visible, but clearly not real content. */
@@ -792,6 +816,25 @@ body.is-phone .journal-view .view-content .journal-day-editing .journal-day-body
 .journal-day-body .cm-contentContainer,
 .journal-day-body .cm-content {
 	padding: 0;
+}
+
+/* Themes add space above Markdown headings as if another paragraph preceded
+   them. The journal date already supplies that separation for the first line. */
+.journal-day-body .markdown-source-view.mod-cm6 .cm-content > .cm-line:first-child {
+	padding-top: 0;
+	margin-top: 0;
+}
+
+/* Backlinks are part of a small daily card, not the bottom of a full-page note. */
+.journal-day-body .embedded-backlinks {
+	margin-block: var(--size-4-5) 0;
+	padding-bottom: 0;
+	min-height: 0;
+}
+
+.journal-day-body .embedded-backlinks .backlink-pane {
+	padding-bottom: 0;
+	min-height: 0;
 }
 
 .journal-day-body .cm-gutters {


### PR DESCRIPTION
Today's card can leave a large gap between its date and the first heading, with more empty space below backlinks, while the title sits close to the card edge. This adjusts the card and header padding, reduces the extra body padding and removes the first editor line's top margin.

Long H1 dates and the Today badge can wrap in a narrow pane. Backlink spacing is more compact, and side padding reduces in smaller panes. All changes stay in the stylesheet; the header-style options and note contents are unchanged.

Validation: typecheck, production build, lint and whitespace checks passed. The CSS was reviewed against the reported Things-theme layout. Live visual testing in Obsidian is still needed, especially with other themes and narrow panes.
