### PR TITLE
Allow hiding today's shaded background

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Some Customization is only visible in the customization menu accessible from the
 | Day order | Oldest to newest | Reverses the complete timeline when set to newest to oldest |
 | Daily header format | `dddd, D MMMM` | Controls how each daily header displays its date |
 | Daily header style | Subtle | Shows each date subtly, as an H1, or hides the date display |
+| Hide today's background | Off | Replaces today's shaded box with a date heading in the theme's emphasis colour |
 | Group days by year | On | Marks year boundaries between consecutive visible daily entries |
 | Group days by month | Off | Groups daily entries beneath compact month and year headings |
 | Focus today on open | On | Opens the journal at today's note and places the cursor there |

--- a/src/main.ts
+++ b/src/main.ts
@@ -324,6 +324,7 @@ export default class JournalViewPlugin extends Plugin {
 				DEFAULT_SETTINGS.openJournalOnStartup,
 			),
 			hideEmptyDays: booleanSetting(saved.hideEmptyDays, DEFAULT_SETTINGS.hideEmptyDays),
+			hideTodayBackground: booleanSetting(saved.hideTodayBackground, DEFAULT_SETTINGS.hideTodayBackground),
 			filterRules: filterRulesSetting(saved.filterRules),
 			showTags: booleanSetting(saved.showTags, DEFAULT_SETTINGS.showTags),
 			displayProperties: propertyNamesSetting(saved.displayProperties),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -52,6 +52,8 @@ export interface JournalViewSettings {
 	openJournalOnStartup: boolean;
 	/** Show only days that have a note (today always shows). */
 	hideEmptyDays: boolean;
+	/** Highlight today with its title colour instead of a shaded card. */
+	hideTodayBackground: boolean;
 	/** Tag and property rules that decide which existing notes are visible. */
 	filterRules: JournalFilterRule[];
 	/** Show frontmatter tags above each existing note's body. */
@@ -78,6 +80,7 @@ export const DEFAULT_SETTINGS: JournalViewSettings = {
 	focusTodayOnOpen: true,
 	openJournalOnStartup: false,
 	hideEmptyDays: true,
+	hideTodayBackground: false,
 	filterRules: [],
 	showTags: false,
 	displayProperties: [],
@@ -91,6 +94,7 @@ type ToggleSettingKey =
 	| "focusTodayOnOpen"
 	| "openJournalOnStartup"
 	| "hideEmptyDays"
+	| "hideTodayBackground"
 	| "showMonthSeparators"
 	| "groupDaysByYear";
 
@@ -231,6 +235,11 @@ export class JournalViewSettingTab extends PluginSettingTab {
 						},
 					},
 					{
+						name: "Hide today's background",
+						desc: "Remove the shaded box around today and use your theme's bold or italic text colour for its date heading.",
+						control: { type: "toggle", key: "hideTodayBackground" },
+					},
+					{
 						name: "Group days by year",
 						desc: "Show a centered year heading when consecutive visible days cross a year boundary.",
 						control: { type: "toggle", key: "groupDaysByYear" },
@@ -357,6 +366,7 @@ export class JournalViewSettingTab extends PluginSettingTab {
 			case "focusTodayOnOpen":
 			case "openJournalOnStartup":
 			case "hideEmptyDays":
+			case "hideTodayBackground":
 			case "showMonthSeparators":
 			case "groupDaysByYear":
 				if (typeof value === "boolean") {

--- a/src/view.ts
+++ b/src/view.ts
@@ -166,6 +166,7 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 
 	async onOpen(): Promise<void> {
 		this.containerEl.addClass("journal-view");
+		this.syncTodayBackground();
 		this.contentEl.empty();
 		this.contentEl.addClass("journal-content");
 
@@ -1366,7 +1367,12 @@ export class JournalView extends ItemView implements DayHost, AnchorHost, Editor
 		});
 	}
 
+	private syncTodayBackground(): void {
+		this.containerEl.toggleClass("journal-today-background-hidden", this.plugin.settings.hideTodayBackground);
+	}
+
 	async onSettingsChanged(): Promise<void> {
+		this.syncTodayBackground();
 		this.plugin.filteredIndex.ensureCurrent();
 		this.syncWithIndex();
 		this.syncFilterButton();

--- a/styles.css
+++ b/styles.css
@@ -731,6 +731,14 @@ button.journal-day-metadata-value-button:focus-visible,
 	--journal-body-pad-bottom: var(--size-4-12);
 }
 
+.journal-today-background-hidden .journal-day-today .journal-day-card {
+	background-color: transparent;
+}
+
+.journal-today-background-hidden .journal-day-today .journal-day-date {
+	color: var(--strong-color, var(--em-color, var(--bold-color, var(--italic-color, var(--text-accent)))));
+}
+
 /* Days without a note yet: visible, but clearly not real content. */
 .journal-day-empty .journal-day-header,
 .journal-day-empty .journal-day-body {


### PR DESCRIPTION
Adds **Hide today's background**, off by default. Enabling it removes today's shaded card background and colours its date heading using the theme's emphasis colour, with an accent-colour fallback.

The setting applies when the view opens and updates immediately when changed. The colour uses the theme's strong, emphasis, bold or italic variables, including Things' emphasis colour. It works with the existing date-header styles and does not depend on the separate spacing change.

Validation: typecheck, production build, lint and whitespace checks passed. The setting's saved value and its presence alongside the upstream controls were checked in the combined fork. Live visual testing in Obsidian is still needed.
